### PR TITLE
Allow excluding traffic by matching headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ openapi.validation.specification-file-path=folder/my-spec.json
 
 # Comma separated list of paths to be excluded from validation. Default is no excluded paths
 openapi.validation.excluded-paths=/_readiness,/_liveness,/_metrics
+# Allows to exclude requests based on headers. Default is no excluded headers.
+# Each entry is the header plus a matching regex. The regex is case insensitive.
+openapi.validation.excluded-headers[0]=User-Agent: .*(bingbot|googlebot).*
 
 # Throttle the validation reporting (logs & metrics) to a maximum of 1 log/metric per 10 seconds.
 # Default is null which results in no throttling.

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/exclusions/ExcludedHeader.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/exclusions/ExcludedHeader.java
@@ -1,0 +1,5 @@
+package com.getyourguide.openapi.validation.api.exclusions;
+
+import java.util.regex.Pattern;
+
+public record ExcludedHeader(String headerName, Pattern headerValuePattern) { }

--- a/openapi-validation-api/src/test/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelectorTest.java
+++ b/openapi-validation-api/src/test/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelectorTest.java
@@ -1,0 +1,56 @@
+package com.getyourguide.openapi.validation.api.selector;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.getyourguide.openapi.validation.api.exclusions.ExcludedHeader;
+import com.getyourguide.openapi.validation.api.model.RequestMetaData;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class DefaultTrafficSelectorTest {
+    private final TrafficSelector trafficSelector = new DefaultTrafficSelector(
+        1.0,
+        null,
+        List.of(
+            new ExcludedHeader("User-Agent", Pattern.compile(".*(bingbot|googlebot).*", Pattern.CASE_INSENSITIVE)),
+            new ExcludedHeader("x-is-bot", Pattern.compile("true", Pattern.CASE_INSENSITIVE))
+        )
+    );
+
+    @Test
+    public void testIsExcludedByHeaderPattern() {
+        assertHeaderIsExcluded(true,
+            "user-Agent", "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)");
+        assertHeaderIsExcluded(false,
+            "User-Agent",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36");
+
+        assertHeaderIsExcluded(true, "x-is-bot", "true");
+        assertHeaderIsExcluded(false, "x-is-bot", "truebot");
+
+    }
+
+    private void assertHeaderIsExcluded(boolean expectedExclusion, String headerName, String headerValue) {
+
+        var request = new RequestMetaData(
+            "GET",
+            URI.create("https://api.example.com/v1/path"),
+            toCaseInsensitiveMap(Map.of(
+                "Content-Type", "application/json",
+                "Content-Length", "10",
+                headerName, headerValue
+            ))
+        );
+        assertEquals(!expectedExclusion, trafficSelector.shouldRequestBeValidated(request));
+    }
+
+    private Map<String, String> toCaseInsensitiveMap(Map<String, String> map) {
+        var newMap = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+        newMap.putAll(map);
+        return newMap;
+    }
+}

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
@@ -2,11 +2,15 @@ package com.getyourguide.openapi.validation;
 
 import static com.getyourguide.openapi.validation.OpenApiValidationApplicationProperties.PROPERTY_PREFIX;
 
+import com.getyourguide.openapi.validation.api.exclusions.ExcludedHeader;
 import com.getyourguide.openapi.validation.api.metrics.MetricTag;
 import com.getyourguide.openapi.validation.util.CommaSeparatedStringsUtil;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -27,6 +31,7 @@ public class OpenApiValidationApplicationProperties {
     private String validationReportMetricName;
     private String validationReportMetricAdditionalTags;
     private String excludedPaths;
+    private List<String> excludedHeaders;
     private Boolean shouldFailOnRequestViolation;
     private Boolean shouldFailOnResponseViolation;
 
@@ -48,5 +53,22 @@ public class OpenApiValidationApplicationProperties {
 
     public Set<String> getExcludedPathsAsSet() {
         return CommaSeparatedStringsUtil.convertCommaSeparatedStringToSet(excludedPaths);
+    }
+
+    public List<ExcludedHeader> getExcludedHeaders() {
+        if (excludedHeaders == null) {
+            return Collections.emptyList();
+        }
+
+        return excludedHeaders.stream()
+            .map(header -> {
+                var parts = header.split(":", 2);
+                if (parts.length != 2) {
+                    return null;
+                }
+                return new ExcludedHeader(parts[0].trim(), Pattern.compile(parts[1].trim(), Pattern.CASE_INSENSITIVE));
+            })
+            .filter(Objects::nonNull)
+            .toList();
     }
 }

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/FallbackLibraryAutoConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/FallbackLibraryAutoConfiguration.java
@@ -24,6 +24,7 @@ public class FallbackLibraryAutoConfiguration {
         return new DefaultTrafficSelector(
             properties.getSampleRate(),
             properties.getExcludedPathsAsSet(),
+            properties.getExcludedHeaders(),
             properties.getShouldFailOnRequestViolation(),
             properties.getShouldFailOnResponseViolation()
         );

--- a/spring-boot-starter/spring-boot-starter-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -16,6 +16,11 @@
       "description": "Comma separated list of paths to be excluded from validation. Default is no excluded paths."
     },
     {
+      "name": "openapi.validation.excluded-headers",
+      "type": "java.util.List<java.lang.String>",
+      "description": "Headers with patterns to be excluded. e.g. `User-Agent: .*(bingbot|googlebot).*`. Default is no excluded paths."
+    },
+    {
       "name": "openapi.validation.validation-report-throttle-wait-seconds",
       "type": "java.lang.Integer",
       "description": "Number of seconds for which the validation report throttler will wait before sending the next report. The property defaults to null. If null or 0, there won't be any throttling."

--- a/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationPropertiesTest.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationPropertiesTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.getyourguide.openapi.validation.api.exclusions.ExcludedHeader;
 import com.getyourguide.openapi.validation.api.metrics.MetricTag;
 import java.util.List;
 import java.util.Set;
@@ -17,6 +18,7 @@ class OpenApiValidationApplicationPropertiesTest {
     private static final String VALIDATION_REPORT_METRIC_NAME = "openapi_validation_error";
     private static final String VALIDATION_REPORT_METRIC_ADDITONAL_TAGS_STRING = "service=payment,team=chk";
     private static final String EXCLUDED_PATHS = "/_readiness,/_liveness,/_metrics";
+    private static final List<String> EXCLUDED_HEADERS = List.of("User-Agent: .*(bingbot|googlebot).*", "x-is-bot: true");
 
     @Test
     void getters() {
@@ -27,21 +29,38 @@ class OpenApiValidationApplicationPropertiesTest {
             VALIDATION_REPORT_METRIC_NAME,
             VALIDATION_REPORT_METRIC_ADDITONAL_TAGS_STRING,
             EXCLUDED_PATHS,
+            EXCLUDED_HEADERS,
             true,
             false
         );
 
         assertEquals(SAMPLE_RATE, loggingConfiguration.getSampleRate());
         assertEquals(SPECIFICATION_FILE_PATH, loggingConfiguration.getSpecificationFilePath());
-        assertEquals(VALIDATION_REPORT_THROTTLE_WAIT_SECONDS, loggingConfiguration.getValidationReportThrottleWaitSeconds());
+        assertEquals(VALIDATION_REPORT_THROTTLE_WAIT_SECONDS,
+            loggingConfiguration.getValidationReportThrottleWaitSeconds());
         assertEquals(VALIDATION_REPORT_METRIC_NAME, loggingConfiguration.getValidationReportMetricName());
         assertEquals(
             List.of(new MetricTag("service", "payment"), new MetricTag("team", "chk")),
             loggingConfiguration.getValidationReportMetricAdditionalTags()
         );
         assertEquals(EXCLUDED_PATHS, loggingConfiguration.getExcludedPaths());
-        assertEquals(Set.of("/_readiness","/_liveness","/_metrics"), loggingConfiguration.getExcludedPathsAsSet());
+        assertExcludedHeaders(loggingConfiguration.getExcludedHeaders());
+        assertEquals(Set.of("/_readiness", "/_liveness", "/_metrics"), loggingConfiguration.getExcludedPathsAsSet());
         assertTrue(loggingConfiguration.getShouldFailOnRequestViolation());
         assertFalse(loggingConfiguration.getShouldFailOnResponseViolation());
+    }
+
+    private void assertExcludedHeaders(List<ExcludedHeader> excludedHeaders) {
+        assertEquals(EXCLUDED_HEADERS.size(), excludedHeaders.size());
+        for (int i = 0; i < EXCLUDED_HEADERS.size(); i++) {
+            assertExcludedHeader(excludedHeaders, i);
+        }
+    }
+
+    private static void assertExcludedHeader(List<ExcludedHeader> excludedHeaders, int index) {
+        var excludedHeader = EXCLUDED_HEADERS.get(index);
+        var parts = excludedHeader.split(":");
+        assertEquals(parts[0].trim(), excludedHeaders.get(index).headerName());
+        assertEquals(parts[1].trim(), excludedHeaders.get(index).headerValuePattern().pattern());
     }
 }


### PR DESCRIPTION
Exclude requests from validation by specifying headers that match a specific pattern.

This allows to exclude requests from bots that are identifiable through headers.

This can be configured through `application.properties` like the following:
```
openapi.validation.excluded-headers[0]=User-Agent: .*(bingbot|googlebot).*
openapi.validation.excluded-headers[1]=x-is-bot: true
```