### PR TITLE
Fix problem with validating partial bodies instead of whole body

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/ValidationReportHandler.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/ValidationReportHandler.java
@@ -83,8 +83,6 @@ public class ValidationReportHandler {
     private boolean isViolationExcluded(OpenApiViolation openApiViolation) {
         return
             violationExclusions.isExcluded(openApiViolation)
-                // JSON parse errors should be ignored as it can't be compared to the schema then (this also prevents logging personal data!)
-                || openApiViolation.getMessage().startsWith("Unable to parse JSON")
                 // If it matches more than 1, then we don't want to log a validation error
                 || openApiViolation.getMessage().matches(
                 ".*\\[Path '[^']+'] Instance failed to match exactly one schema \\(matched [1-9][0-9]* out of \\d\\).*");

--- a/spring-boot-starter/spring-boot-starter-webflux-spring2.7/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
+++ b/spring-boot-starter/spring-boot-starter-webflux-spring2.7/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
@@ -10,6 +10,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
 import org.springframework.lang.NonNull;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.SignalType;
 
 public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDecorator {
     private final TrafficSelector trafficSelector;
@@ -38,11 +39,19 @@ public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDeco
             return super.getBody();
         }
 
-        return super.getBody().doOnNext(dataBuffer -> {
-            cachedBody = dataBuffer.toString(StandardCharsets.UTF_8);
-            if (onBodyCachedListener != null) {
-                onBodyCachedListener.run();
-            }
-        });
+        return super.getBody()
+            .doOnNext(dataBuffer -> {
+                if (cachedBody == null) {
+                    cachedBody = "";
+                }
+                cachedBody += dataBuffer.toString(StandardCharsets.UTF_8);
+            })
+            .doFinally(signalType -> {
+                if (signalType == SignalType.ON_COMPLETE) {
+                    if (onBodyCachedListener != null) {
+                        onBodyCachedListener.run();
+                    }
+                }
+            });
     }
 }

--- a/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
@@ -10,6 +10,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
 import org.springframework.lang.NonNull;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.SignalType;
 
 public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDecorator {
     private final TrafficSelector trafficSelector;
@@ -38,11 +39,19 @@ public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDeco
             return super.getBody();
         }
 
-        return super.getBody().doOnNext(dataBuffer -> {
-            cachedBody = dataBuffer.toString(StandardCharsets.UTF_8);
-            if (onBodyCachedListener != null) {
-                onBodyCachedListener.run();
-            }
-        });
+        return super.getBody()
+            .doOnNext(dataBuffer -> {
+                if (cachedBody == null) {
+                    cachedBody = "";
+                }
+                cachedBody += dataBuffer.toString(StandardCharsets.UTF_8);
+            })
+            .doFinally(signalType -> {
+                if (signalType == SignalType.ON_COMPLETE) {
+                    if (onBodyCachedListener != null) {
+                        onBodyCachedListener.run();
+                    }
+                }
+            });
     }
 }


### PR DESCRIPTION
The body is often sent in chunks and therefore the current logic in the `BodyCachingServerHttpRequestDecorator` was flawed so that it would just cache the last chunk retrieved instead of all of the chunks together.

This was most likely also the reason for the "Unable to parse JSON" which exclusion is now removed.