### PR TITLE
Disable validation instead of failing (multiple spec files)

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
@@ -60,6 +60,12 @@ public class OpenApiInteractionValidatorFactory {
             })
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
+
+        if (validators.isEmpty()) {
+            log.info("OpenAPI spec file(s) could not be found [validation disabled]");
+            return null;
+        }
+
         return new MultipleSpecOpenApiInteractionValidatorWrapper(validators);
     }
 


### PR DESCRIPTION
### Problem

If one uses the multiple openapi specification files setup and they don't exist locally as defined in the configuration, then spring boot will not start up anymore due to an assertion error.

### Solution

Handle this case the same way as if a single spec file can't be found -> Disable spec validation.