### PR TITLE
Refactor: Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ openapi.validation.excluded-headers[0]=User-Agent: .*(bingbot|googlebot).*
 openapi.validation.validation-report-throttle-wait-seconds=10
 
 # Throttle the validation reporting (logs & metrics) to a maximum of 1 log/metric per 10 seconds.
-# Default is "openapi.validation.error".
-openapi.validation.validation-report-metric-name=openapi.violation
+# Default is "openapi.validation".
+openapi.validation.validation-report-metric-name=validation.openapi
 
 # Add additional tags to be logged with metrics. They should be in the format {KEY}={VALUE},{KEY}={VALUE}
 # Default is no additional tags.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ result in a violation error with log level `warn`.
 
 ```java
 @Configuration
-public class ValidatorConfiguration {
+public class OpenApiValidatorConfiguration {
     @Bean
     public ValidatorConfiguration buildValidatorConfiguration() {
         return new ValidatorConfigurationBuilder()

--- a/examples/example-spring-boot-starter-web-spring2.7/src/main/java/com/getyourguide/openapi/validation/example/configuration/ExampleConfiguration.java
+++ b/examples/example-spring-boot-starter-web-spring2.7/src/main/java/com/getyourguide/openapi/validation/example/configuration/ExampleConfiguration.java
@@ -1,17 +1,17 @@
 package com.getyourguide.openapi.validation.example.configuration;
 
 import com.getyourguide.openapi.validation.api.log.LoggerExtension;
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
 import com.getyourguide.openapi.validation.example.logging.ExampleLoggerExtension;
-import com.getyourguide.openapi.validation.metrics.LoggingMetricsReporter;
+import com.getyourguide.openapi.validation.metrics.client.LoggingMetricsClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ExampleConfiguration {
     @Bean
-    public MetricsReporter metricsReporter() {
-        return new LoggingMetricsReporter();
+    public MetricsClient metricsClient() {
+        return new LoggingMetricsClient();
     }
 
     @Bean

--- a/examples/example-spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/example/configuration/ExampleConfiguration.java
+++ b/examples/example-spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/example/configuration/ExampleConfiguration.java
@@ -1,17 +1,17 @@
 package com.getyourguide.openapi.validation.example.configuration;
 
 import com.getyourguide.openapi.validation.api.log.LoggerExtension;
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
 import com.getyourguide.openapi.validation.example.logging.ExampleLoggerExtension;
-import com.getyourguide.openapi.validation.metrics.LoggingMetricsReporter;
+import com.getyourguide.openapi.validation.metrics.client.LoggingMetricsClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class ExampleConfiguration {
     @Bean
-    public MetricsReporter metricsReporter() {
-        return new LoggingMetricsReporter();
+    public MetricsClient metricsClient() {
+        return new LoggingMetricsClient();
     }
 
     @Bean

--- a/metrics-reporter/metrics-reporter-datadog-spring-boot/src/main/java/com/getyourguide/openapi/validation/metrics/datadog/autoconfigure/FallbackLibraryAutoConfiguration.java
+++ b/metrics-reporter/metrics-reporter-datadog-spring-boot/src/main/java/com/getyourguide/openapi/validation/metrics/datadog/autoconfigure/FallbackLibraryAutoConfiguration.java
@@ -1,7 +1,7 @@
 package com.getyourguide.openapi.validation.metrics.datadog.autoconfigure;
 
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
-import com.getyourguide.openapi.validation.metrics.datadog.StatsDClientMetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
+import com.getyourguide.openapi.validation.metrics.datadog.client.StatsDClientMetricsClient;
 import com.timgroup.statsd.StatsDClient;
 import lombok.AllArgsConstructor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -18,8 +18,8 @@ public class FallbackLibraryAutoConfiguration {
     @Bean
     @ConditionalOnBean(StatsDClient.class)
     @ConditionalOnMissingBean
-    public MetricsReporter metricsReporterStatsDClient(StatsDClient statsDClient) {
-        return new StatsDClientMetricsReporter(statsDClient);
+    public MetricsClient metricsClientStatsDClient(StatsDClient statsDClient) {
+        return new StatsDClientMetricsClient(statsDClient);
     }
 
 }

--- a/metrics-reporter/metrics-reporter-datadog-spring-boot/src/main/java/com/getyourguide/openapi/validation/metrics/datadog/autoconfigure/LibraryAutoConfiguration.java
+++ b/metrics-reporter/metrics-reporter-datadog-spring-boot/src/main/java/com/getyourguide/openapi/validation/metrics/datadog/autoconfigure/LibraryAutoConfiguration.java
@@ -3,9 +3,9 @@ package com.getyourguide.openapi.validation.metrics.datadog.autoconfigure;
 import static com.getyourguide.openapi.validation.metrics.datadog.OpenApiValidationDataDogMetricsApplicationProperties.PROPERTY_STATSD_SERVICE_HOST;
 import static com.getyourguide.openapi.validation.metrics.datadog.OpenApiValidationDataDogMetricsApplicationProperties.PROPERTY_STATSD_SERVICE_PORT;
 
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
 import com.getyourguide.openapi.validation.metrics.datadog.OpenApiValidationDataDogMetricsApplicationProperties;
-import com.getyourguide.openapi.validation.metrics.datadog.StatsDClientMetricsReporter;
+import com.getyourguide.openapi.validation.metrics.datadog.client.StatsDClientMetricsClient;
 import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
 import lombok.AllArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -23,12 +23,12 @@ public class LibraryAutoConfiguration {
     @Bean
     @ConditionalOnClass(name = "com.timgroup.statsd.StatsDClient")
     @ConditionalOnProperty({PROPERTY_STATSD_SERVICE_HOST, PROPERTY_STATSD_SERVICE_PORT})
-    public MetricsReporter metricsReporterCustomStatsDClient() {
+    public MetricsClient metricsClientCustomStatsDClient() {
         var statsDClient = new NonBlockingStatsDClientBuilder()
             .prefix(properties.getMetricPrefix())
             .hostname(properties.getStatsd().getService().getHost())
             .port(properties.getStatsd().getService().getPort())
             .build();
-        return new StatsDClientMetricsReporter(statsDClient);
+        return new StatsDClientMetricsClient(statsDClient);
     }
 }

--- a/metrics-reporter/metrics-reporter-datadog-spring-boot/src/test/java/com/getyourguide/openapi/validation/metrics/datadog/autoconfigure/LibraryAutoConfigurationMetricsLoggerTest.java
+++ b/metrics-reporter/metrics-reporter-datadog-spring-boot/src/test/java/com/getyourguide/openapi/validation/metrics/datadog/autoconfigure/LibraryAutoConfigurationMetricsLoggerTest.java
@@ -3,8 +3,8 @@ package com.getyourguide.openapi.validation.metrics.datadog.autoconfigure;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
-import com.getyourguide.openapi.validation.metrics.datadog.StatsDClientMetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
+import com.getyourguide.openapi.validation.metrics.datadog.client.StatsDClientMetricsClient;
 import com.timgroup.statsd.StatsDClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -24,7 +24,7 @@ class LibraryAutoConfigurationMetricsLoggerTest {
     }
 
     @Test
-    void withDataDogPropertiesShouldCreateStatsDClientMetricsReporter() {
+    void withDataDogPropertiesShouldCreateStatsDClientMetricsClient() {
         contextRunner
             .withPropertyValues(
                 "openapi.validation.datadog.statsd.service.host=localhost",
@@ -32,15 +32,15 @@ class LibraryAutoConfigurationMetricsLoggerTest {
             )
             .run(context -> {
                 assertThat(context)
-                    .hasSingleBean(MetricsReporter.class);
-                assertThat(context.getBeansOfType(MetricsReporter.class))
-                    .extractingByKey("metricsReporterCustomStatsDClient")
-                    .isInstanceOf(StatsDClientMetricsReporter.class);
+                    .hasSingleBean(MetricsClient.class);
+                assertThat(context.getBeansOfType(MetricsClient.class))
+                    .extractingByKey("metricsClientCustomStatsDClient")
+                    .isInstanceOf(StatsDClientMetricsClient.class);
             });
     }
 
     @Test
-    void withStatsDClientPropertiesAndExistingStatsDClientShouldCreateNewStatsDClientAndCreateStatsDClientMetricsReporter() {
+    void withStatsDClientPropertiesAndExistingStatsDClientShouldCreateNewStatsDClientAndCreateStatsDClientMetricsClient() {
         contextRunner
             .withPropertyValues(
                 "openapi.validation.datadog.statsd.service.host=localhost",
@@ -49,10 +49,10 @@ class LibraryAutoConfigurationMetricsLoggerTest {
             .withBean(StatsDClient.class, () -> mock(StatsDClient.class))
             .run(context -> {
                 assertThat(context)
-                    .hasSingleBean(MetricsReporter.class);
-                assertThat(context.getBeansOfType(MetricsReporter.class))
-                    .extractingByKey("metricsReporterCustomStatsDClient")
-                    .isInstanceOf(StatsDClientMetricsReporter.class);
+                    .hasSingleBean(MetricsClient.class);
+                assertThat(context.getBeansOfType(MetricsClient.class))
+                    .extractingByKey("metricsClientCustomStatsDClient")
+                    .isInstanceOf(StatsDClientMetricsClient.class);
             });
     }
 
@@ -63,10 +63,10 @@ class LibraryAutoConfigurationMetricsLoggerTest {
             .withBean(StatsDClient.class, () -> mock(StatsDClient.class))
             .run(context -> {
                 assertThat(context)
-                    .hasSingleBean(MetricsReporter.class);
-                assertThat(context.getBeansOfType(MetricsReporter.class))
-                    .extractingByKey("metricsReporterStatsDClient")
-                    .isInstanceOf(StatsDClientMetricsReporter.class);
+                    .hasSingleBean(MetricsClient.class);
+                assertThat(context.getBeansOfType(MetricsClient.class))
+                    .extractingByKey("metricsClientStatsDClient")
+                    .isInstanceOf(StatsDClientMetricsClient.class);
             });
     }
 
@@ -75,7 +75,7 @@ class LibraryAutoConfigurationMetricsLoggerTest {
         contextRunner
             .run(context -> {
                 assertThat(context)
-                    .doesNotHaveBean(MetricsReporter.class);
+                    .doesNotHaveBean(MetricsClient.class);
             });
     }
 }

--- a/metrics-reporter/metrics-reporter-datadog/src/main/java/com/getyourguide/openapi/validation/metrics/datadog/client/StatsDClientMetricsClient.java
+++ b/metrics-reporter/metrics-reporter-datadog/src/main/java/com/getyourguide/openapi/validation/metrics/datadog/client/StatsDClientMetricsClient.java
@@ -1,17 +1,15 @@
-package com.getyourguide.openapi.validation.metrics.datadog;
+package com.getyourguide.openapi.validation.metrics.datadog.client;
 
 import com.getyourguide.openapi.validation.api.metrics.MetricTag;
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
 import com.timgroup.statsd.StatsDClient;
 import java.util.Arrays;
 import java.util.Optional;
+import lombok.AllArgsConstructor;
 
-public class StatsDClientMetricsReporter implements MetricsReporter {
+@AllArgsConstructor
+public class StatsDClientMetricsClient implements MetricsClient {
     private final StatsDClient statsDClient;
-
-    public StatsDClientMetricsReporter(StatsDClient statsDClient) {
-        this.statsDClient = statsDClient;
-    }
 
     @Override
     public void increment(String aspect, MetricTag... tags) {
@@ -20,7 +18,9 @@ public class StatsDClientMetricsReporter implements MetricsReporter {
 
     private static String[] mapTags(MetricTag[] tags) {
         return Optional.of(tags)
-            .map(nonNullTags -> Arrays.stream(nonNullTags).map(tag -> tag.getKey() + ":" + tag.getValue()).toArray(String[]::new))
+            .map(nonNullTags ->
+                Arrays.stream(nonNullTags).map(tag -> tag.getKey() + ":" + tag.getValue()).toArray(String[]::new)
+            )
             .orElse(new String[0]);
     }
 }

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
@@ -16,10 +16,11 @@ public class DefaultMetricsReporter implements MetricsReporter {
 
     @Override
     public void reportViolation(OpenApiViolation violation) {
-        metricsClient.increment(configuration.getMetricName(), createTags(violation));
+        var violationMetricName = configuration.getMetricName() + ".error";
+        metricsClient.increment(violationMetricName, createTagsForViolation(violation));
     }
 
-    private MetricTag[] createTags(OpenApiViolation violation) {
+    private MetricTag[] createTagsForViolation(OpenApiViolation violation) {
         var tags = new ArrayList<MetricTag>();
 
         tags.add(new MetricTag("type", violation.getDirection().toString().toLowerCase()));

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
@@ -1,0 +1,44 @@
+package com.getyourguide.openapi.validation.api.metrics;
+
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
+import com.getyourguide.openapi.validation.api.model.OpenApiViolation;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class DefaultMetricsReporter implements MetricsReporter {
+
+    private final MetricsClient metricsClient;
+    private final Configuration configuration;
+
+    @Override
+    public void reportViolation(OpenApiViolation violation) {
+        metricsClient.increment(configuration.getMetricName(), createTags(violation));
+    }
+
+    private MetricTag[] createTags(OpenApiViolation violation) {
+        var tags = new ArrayList<MetricTag>();
+
+        tags.add(new MetricTag("type", violation.getDirection().toString().toLowerCase()));
+        tags.add(new MetricTag("method", violation.getRequestMetaData().getMethod().toLowerCase()));
+        violation.getNormalizedPath().ifPresent(path -> tags.add(new MetricTag("path", path)));
+        violation.getResponseStatus()
+            .ifPresent(responseStatus -> tags.add(new MetricTag("status", responseStatus.toString())));
+
+        if (configuration.getMetricAdditionalTags() != null) {
+            tags.addAll(configuration.getMetricAdditionalTags());
+        }
+
+        return tags.toArray(MetricTag[]::new);
+    }
+
+    @Builder
+    @Getter
+    public static class Configuration {
+        private final String metricName;
+        private final List<MetricTag> metricAdditionalTags;
+    }
+}

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricsReporter.java
@@ -1,5 +1,7 @@
 package com.getyourguide.openapi.validation.api.metrics;
 
+import com.getyourguide.openapi.validation.api.model.OpenApiViolation;
+
 public interface MetricsReporter {
-    void increment(String aspect, MetricTag... tags);
+    void reportViolation(OpenApiViolation violation);
 }

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/NoOpMetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/NoOpMetricsReporter.java
@@ -1,8 +1,0 @@
-package com.getyourguide.openapi.validation.api.metrics;
-
-public class NoOpMetricsReporter implements MetricsReporter {
-    @Override
-    public void increment(String aspect, MetricTag... tags) {
-        // Do nothing
-    }
-}

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/client/MetricsClient.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/client/MetricsClient.java
@@ -1,0 +1,7 @@
+package com.getyourguide.openapi.validation.api.metrics.client;
+
+import com.getyourguide.openapi.validation.api.metrics.MetricTag;
+
+public interface MetricsClient {
+    void increment(String aspect, MetricTag... tags);
+}

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/client/NoOpMetricsClient.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/client/NoOpMetricsClient.java
@@ -1,0 +1,10 @@
+package com.getyourguide.openapi.validation.api.metrics.client;
+
+import com.getyourguide.openapi.validation.api.metrics.MetricTag;
+
+public class NoOpMetricsClient implements MetricsClient {
+    @Override
+    public void increment(String aspect, MetricTag... tags) {
+        // no-op
+    }
+}

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
@@ -31,7 +31,7 @@ import org.springframework.context.annotation.Configuration;
 @AllArgsConstructor
 public class LibraryAutoConfiguration {
 
-    public static final String DEFAULT_METRIC_NAME = "openapi.validation.error";
+    public static final String DEFAULT_METRIC_NAME = "openapi.validation";
 
     private final OpenApiValidationApplicationProperties properties;
 

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/metrics/client/LoggingMetricsClient.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/metrics/client/LoggingMetricsClient.java
@@ -1,11 +1,11 @@
-package com.getyourguide.openapi.validation.metrics;
+package com.getyourguide.openapi.validation.metrics.client;
 
 import com.getyourguide.openapi.validation.api.metrics.MetricTag;
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class LoggingMetricsReporter implements MetricsReporter {
+public class LoggingMetricsClient implements MetricsClient {
 
     @Override
     public void increment(String aspect, MetricTag... tags) {

--- a/spring-boot-starter/spring-boot-starter-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -28,7 +28,7 @@
     {
       "name": "openapi.validation.validation-report-metric-name",
       "type": "java.lang.String",
-      "description": "Metric name to be used when reporting violations with the MetricsReporter. The property defaults to 'openapi.validation.error'."
+      "description": "Metric name to be used when reporting violations with the MetricsReporter. The property defaults to 'openapi.validation'."
     },
     {
       "name": "openapi.validation.validation-report-metric-additional-tags",

--- a/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationPropertiesTest.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationPropertiesTest.java
@@ -15,7 +15,7 @@ class OpenApiValidationApplicationPropertiesTest {
     private static final Double SAMPLE_RATE = 0.001;
     private static final String SPECIFICATION_FILE_PATH = "/tmp/openapi.yaml";
     private static final Integer VALIDATION_REPORT_THROTTLE_WAIT_SECONDS = 10;
-    private static final String VALIDATION_REPORT_METRIC_NAME = "openapi_validation_error";
+    private static final String VALIDATION_REPORT_METRIC_NAME = "openapi_validation";
     private static final String VALIDATION_REPORT_METRIC_ADDITONAL_TAGS_STRING = "service=payment,team=chk";
     private static final String EXCLUDED_PATHS = "/_readiness,/_liveness,/_metrics";
     private static final List<String> EXCLUDED_HEADERS = List.of("User-Agent: .*(bingbot|googlebot).*", "x-is-bot: true");

--- a/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfigurationMetricsLoggerTest.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfigurationMetricsLoggerTest.java
@@ -2,7 +2,7 @@ package com.getyourguide.openapi.validation.autoconfigure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.metrics.client.MetricsClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener;
@@ -21,13 +21,13 @@ class LibraryAutoConfigurationMetricsLoggerTest {
     }
 
     @Test
-    void noPropertiesWithoutExistingStatsDClientBeanShouldNotReturnAnyDefaultMetricsReporter() {
-        // Note: We don't want to return any MetricsReporter as this can conflict with other MetricsReporter beans
+    void noPropertiesWithoutExistingStatsDClientBeanShouldNotReturnAnyDefaultMetricsClient() {
+        // Note: We don't want to return any MetricsClient as this can conflict with other MetricsClient beans
         //       like the one provided by metrics-reporter-datadog-spring-boot.
         contextRunner
             .run(context -> {
                 assertThat(context)
-                    .doesNotHaveBean(MetricsReporter.class);
+                    .doesNotHaveBean(MetricsClient.class);
             });
     }
 }


### PR DESCRIPTION
1. Separate out the MetricsClient
2. Move metrics logic into MetricsReporter (that now doesn't contain the datadog specific code anymore)
3. Metric name to not include `.error` anymore so that it can be used also for `.startup`.