### PR TITLE
Bugfix: Catch RejectedExecutionException and skip validation

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
@@ -13,6 +13,7 @@ import com.getyourguide.openapi.validation.api.model.ValidatorConfiguration;
 import com.getyourguide.openapi.validation.core.validator.OpenApiInteractionValidatorWrapper;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
@@ -42,11 +43,18 @@ public class OpenApiRequestValidator {
     }
 
     public void validateRequestObjectAsync(final RequestMetaData request, String requestBody) {
-        threadPool.execute(() -> validateRequestObject(request, requestBody));
+        executeAsync(() -> validateRequestObject(request, requestBody));
     }
 
     public void validateResponseObjectAsync(final RequestMetaData request, ResponseMetaData response, final String responseBody) {
-        threadPool.execute(() -> validateResponseObject(request, response, responseBody));
+        executeAsync(() -> validateResponseObject(request, response, responseBody));
+    }
+
+    private void executeAsync(Runnable command) {
+        try {
+            threadPool.execute(command);
+        } catch(RejectedExecutionException ignored) {
+        }
     }
 
     public ValidationResult validateRequestObject(final RequestMetaData request, String requestBody) {

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
@@ -54,7 +54,7 @@ public class OpenApiRequestValidator {
     private void executeAsync(Runnable command) {
         try {
             threadPool.execute(command);
-        } catch(RejectedExecutionException ignored) {
+        } catch (RejectedExecutionException ignored) {
         }
     }
 

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
@@ -12,27 +12,25 @@ import com.getyourguide.openapi.validation.api.model.ValidationResult;
 import com.getyourguide.openapi.validation.api.model.ValidatorConfiguration;
 import com.getyourguide.openapi.validation.core.validator.OpenApiInteractionValidatorWrapper;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.utils.URLEncodedUtils;
 
 @Slf4j
 public class OpenApiRequestValidator {
-    private final ThreadPoolExecutor threadPool;
+    private final ThreadPoolExecutor threadPoolExecutor;
     private final OpenApiInteractionValidatorWrapper validator;
     private final ValidationReportHandler validationReportHandler;
 
     public OpenApiRequestValidator(
-        ThreadPoolExecutor threadPool,
+        ThreadPoolExecutor threadPoolExecutor,
         ValidationReportHandler validationReportHandler,
         MetricsReporter metricsReporter,
         String specificationFilePath,
         ValidatorConfiguration configuration
     ) {
-        this.threadPool = threadPool;
+        this.threadPoolExecutor = threadPoolExecutor;
         this.validator = new OpenApiInteractionValidatorFactory().build(specificationFilePath, configuration);
         this.validationReportHandler = validationReportHandler;
 
@@ -53,8 +51,9 @@ public class OpenApiRequestValidator {
 
     private void executeAsync(Runnable command) {
         try {
-            threadPool.execute(command);
+            threadPoolExecutor.execute(command);
         } catch (RejectedExecutionException ignored) {
+            // ignored
         }
     }
 

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
@@ -21,17 +21,18 @@ import org.apache.http.client.utils.URLEncodedUtils;
 
 @Slf4j
 public class OpenApiRequestValidator {
-    private final ThreadPoolExecutor threadPool = new ThreadPoolExecutor(2, 2, 1000L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(10));
-
+    private final ThreadPoolExecutor threadPool;
     private final OpenApiInteractionValidatorWrapper validator;
     private final ValidationReportHandler validationReportHandler;
 
     public OpenApiRequestValidator(
+        ThreadPoolExecutor threadPool,
         ValidationReportHandler validationReportHandler,
         MetricsReporter metricsReporter,
         String specificationFilePath,
         ValidatorConfiguration configuration
     ) {
+        this.threadPool = threadPool;
         this.validator = new OpenApiInteractionValidatorFactory().build(specificationFilePath, configuration);
         this.validationReportHandler = validationReportHandler;
 

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
@@ -1,0 +1,42 @@
+package com.getyourguide.openapi.validation.core;
+
+import static org.mockito.Mockito.mock;
+
+import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.model.ValidatorConfiguration;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class OpenApiRequestValidatorTest {
+
+    private ThreadPoolExecutor threadPoolExecutor;
+    private ValidationReportHandler validationReportHandler;
+    private MetricsReporter metricsReporter;
+
+    private OpenApiRequestValidator openApiRequestValidator;
+
+    @BeforeEach
+    public void setup() {
+        threadPoolExecutor = mock();
+        validationReportHandler = mock();
+        metricsReporter = mock();
+
+        openApiRequestValidator = new OpenApiRequestValidator(
+            threadPoolExecutor,
+            validationReportHandler,
+            metricsReporter,
+            "",
+            new ValidatorConfiguration(null, null, null)
+        );
+    }
+
+    @Test
+    public void testWhenThreadPoolExecutorRejectsExecutionThenItShouldNotThrow() {
+        Mockito.doThrow(new RejectedExecutionException()).when(threadPoolExecutor).execute(Mockito.any());
+
+        openApiRequestValidator.validateRequestObjectAsync(mock(), null);
+    }
+}

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
@@ -13,16 +13,14 @@ import org.mockito.Mockito;
 public class OpenApiRequestValidatorTest {
 
     private ThreadPoolExecutor threadPoolExecutor;
-    private ValidationReportHandler validationReportHandler;
-    private MetricsReporter metricsReporter;
 
     private OpenApiRequestValidator openApiRequestValidator;
 
     @BeforeEach
     public void setup() {
         threadPoolExecutor = mock();
-        validationReportHandler = mock();
-        metricsReporter = mock();
+        ValidationReportHandler validationReportHandler = mock();
+        MetricsReporter metricsReporter = mock();
 
         openApiRequestValidator = new OpenApiRequestValidator(
             threadPoolExecutor,

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
@@ -99,8 +99,17 @@ public class LibraryAutoConfiguration {
         MetricsReporter metricsReporter,
         ValidatorConfiguration validatorConfiguration
     ) {
+        var threadPoolExecutor = new ThreadPoolExecutor(
+            2,
+            2,
+            1000L,
+            TimeUnit.MILLISECONDS,
+            new LinkedBlockingQueue<>(10),
+            new ThreadPoolExecutor.DiscardPolicy()
+        );
+
         return new OpenApiRequestValidator(
-            new ThreadPoolExecutor(2, 2, 1000L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(10)),
+            threadPoolExecutor,
             validationReportHandler,
             metricsReporter,
             properties.getSpecificationFilePath(),

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
@@ -20,6 +20,9 @@ import com.getyourguide.openapi.validation.core.throttle.RequestBasedValidationR
 import com.getyourguide.openapi.validation.core.throttle.ValidationReportThrottler;
 import com.getyourguide.openapi.validation.core.throttle.ValidationReportThrottlerNone;
 import java.util.Optional;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -97,6 +100,7 @@ public class LibraryAutoConfiguration {
         ValidatorConfiguration validatorConfiguration
     ) {
         return new OpenApiRequestValidator(
+            new ThreadPoolExecutor(2, 2, 1000L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(10)),
             validationReportHandler,
             metricsReporter,
             properties.getSpecificationFilePath(),


### PR DESCRIPTION
`ThreadPoolExecutor.execute` can throw RejectedExecutionException. If it does, we just want to ignore it and skip validation for that request. This way we guarantee the request going through in those cases.