### PR TITLE
Add validation heartbeat metric

### DIFF
--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
@@ -16,14 +16,17 @@ public class DefaultMetricsReporter implements MetricsReporter {
 
     @Override
     public void reportViolation(OpenApiViolation violation) {
-        String violationMetricName = buildMetricName(".error");
-        metricsClient.increment(violationMetricName, createTagsForViolation(violation));
+        metricsClient.increment(buildMetricName(".error"), createTagsForViolation(violation));
     }
 
     @Override
     public void reportStartup(boolean isValidationEnabled) {
-        String startupMetricName = buildMetricName(".startup");
-        metricsClient.increment(startupMetricName, createTagsForStartup(isValidationEnabled));
+        metricsClient.increment(buildMetricName(".startup"), createTagsForStartup(isValidationEnabled));
+    }
+
+    @Override
+    public void reportValidationHeartbeat() {
+        metricsClient.increment(buildMetricName(".validation_heartbeat"), createTagsForValidation());
     }
 
     private String buildMetricName(String suffix) {
@@ -50,6 +53,12 @@ public class DefaultMetricsReporter implements MetricsReporter {
         tags.add(new MetricTag("validation_enabled", String.valueOf(isValidationEnabled)));
         addAdditionalTags(tags);
 
+        return tags.toArray(MetricTag[]::new);
+    }
+
+    private MetricTag[] createTagsForValidation() {
+        var tags = new ArrayList<MetricTag>();
+        addAdditionalTags(tags);
         return tags.toArray(MetricTag[]::new);
     }
 

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricsReporter.java
@@ -6,4 +6,6 @@ public interface MetricsReporter {
     void reportViolation(OpenApiViolation violation);
 
     void reportStartup(boolean isValidationEnabled);
+
+    void reportValidationHeartbeat();
 }


### PR DESCRIPTION
## Problem
We want to be able to know which services are actively validating traffic. There are several reasons why validation could not be happening. It could be due to no traffic being selected at all or some other problems.

## Solution
When validation happens increment a heartbeat metric that shows that validation is happening. But don't do this for every request. Only do it once every hour.