### PR TITLE
Show parameter name in violation log

### DIFF
--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/model/OpenApiViolation.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/model/OpenApiViolation.java
@@ -16,6 +16,7 @@ public class OpenApiViolation {
     private final Optional<String> operationId;
     private final Optional<String> normalizedPath;
     private final Optional<String> instance;
+    private final Optional<String> parameter;
     private final Optional<String> schema;
     private final Optional<Integer> responseStatus;
     private final String message;

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/DefaultViolationLogger.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/DefaultViolationLogger.java
@@ -37,6 +37,7 @@ public class DefaultViolationLogger implements ViolationLogger {
         violation.getNormalizedPath().ifPresent(normalizedPath -> context.put("validation.api.path", normalizedPath));
         violation.getOperationId().ifPresent(operationId -> context.put("validation.api.operation_id", operationId));
         violation.getInstance().ifPresent(instance -> context.put("validation.instance", instance));
+        violation.getParameter().ifPresent(instance -> context.put("validation.parameter", instance));
         return context;
     }
 }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/ValidationReportHandlerTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/ValidationReportHandlerTest.java
@@ -27,8 +27,6 @@ import org.mockito.ArgumentCaptor;
 class ValidationReportHandlerTest {
     private ValidationReportThrottler throttleHelper;
     private ViolationLogger logger;
-    private MetricsReporter metrics;
-    private ViolationExclusions violationExclusions;
 
     private ValidationReportHandler validationReportHandler;
 
@@ -36,8 +34,8 @@ class ValidationReportHandlerTest {
     public void setUp() {
         throttleHelper = mock();
         logger = mock();
-        metrics = mock();
-        violationExclusions = mock();
+        MetricsReporter metrics = mock();
+        ViolationExclusions violationExclusions = mock();
 
         validationReportHandler = new ValidationReportHandler(throttleHelper, logger, metrics, violationExclusions);
     }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/ValidationReportHandlerTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/ValidationReportHandlerTest.java
@@ -1,0 +1,94 @@
+package com.getyourguide.openapi.validation.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.atlassian.oai.validator.report.ValidationReport;
+import com.getyourguide.openapi.validation.api.exclusions.ViolationExclusions;
+import com.getyourguide.openapi.validation.api.log.ViolationLogger;
+import com.getyourguide.openapi.validation.api.metrics.MetricsReporter;
+import com.getyourguide.openapi.validation.api.model.Direction;
+import com.getyourguide.openapi.validation.api.model.OpenApiViolation;
+import com.getyourguide.openapi.validation.api.model.RequestMetaData;
+import com.getyourguide.openapi.validation.core.throttle.ValidationReportThrottler;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class ValidationReportHandlerTest {
+    private ValidationReportThrottler throttleHelper;
+    private ViolationLogger logger;
+    private MetricsReporter metrics;
+    private ViolationExclusions violationExclusions;
+
+    private ValidationReportHandler validationReportHandler;
+
+    @BeforeEach
+    public void setUp() {
+        throttleHelper = mock();
+        logger = mock();
+        metrics = mock();
+        violationExclusions = mock();
+
+        validationReportHandler = new ValidationReportHandler(throttleHelper, logger, metrics, violationExclusions);
+    }
+
+    @Test
+    public void testWhenParameterNameIsPresentThenItShouldAddItToTheMessage() {
+        mockNoThrottling();
+        var request = mockRequestMetaData();
+        var validationReport = mockValidationReport("parameterName");
+
+        validationReportHandler.handleValidationReport(request, Direction.REQUEST, null, validationReport);
+
+        var argumentCaptor = ArgumentCaptor.forClass(OpenApiViolation.class);
+        verify(logger).log(argumentCaptor.capture());
+        var openApiViolation = argumentCaptor.getValue();
+        assertEquals(Optional.of("parameterName"), openApiViolation.getParameter());
+        assertEquals(
+            String.join("\n",
+                "OpenAPI spec validation error [key]",
+                "GET https://api.example.com/index",
+                "User Agent: null",
+                "Parameter: parameterName",
+                "",
+                "Violation message (toString)"),
+            openApiViolation.getLogMessage());
+    }
+
+    private static RequestMetaData mockRequestMetaData() {
+        var request = new RequestMetaData("GET", URI.create("https://api.example.com/index"), new HashMap<>());
+        return request;
+    }
+
+    private static ValidationReport mockValidationReport(String parameterName) {
+        var validationReport = mock(ValidationReport.class);
+        var message = mock(ValidationReport.Message.class);
+        when(message.getKey()).thenReturn("key");
+        when(message.getMessage()).thenReturn("Violation message");
+        when(message.toString()).thenReturn("Violation message (toString)");
+        var context = mock(ValidationReport.MessageContext.class);
+        var parameter = mock(Parameter.class);
+        when(parameter.getName()).thenReturn(parameterName);
+        when(context.getParameter()).thenReturn(Optional.of(parameter));
+        when(message.getContext()).thenReturn(Optional.of(context));
+        when(validationReport.getMessages()).thenReturn(List.of(message));
+        return validationReport;
+    }
+
+    private void mockNoThrottling() {
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArguments()[1]).run();
+            return null;
+        }).when(throttleHelper).throttle(any(), any());
+    }
+}


### PR DESCRIPTION
This will show the parameter name in the violation in case the violation is happening on a parameter. Without this it was hard to find out which parameter was actually causing the violation.

New:
```
GET http://localhost:8080/?fromDate=1&ids=123%252C2%252C3%2526testing
User Agent: curl/7.88.1
Instance: /
Parameter: ids

INFO - Instance type (string) does not match any allowed primitive type (allowed: ["integer"]): []
```

Before:
```
GET http://localhost:8080/?fromDate=1&ids=123%252C2%252C3%2526testing
User Agent: curl/7.88.1
Instance: /

INFO - Instance type (string) does not match any allowed primitive type (allowed: ["integer"]): []
```