### PR TITLE
Update swagger-request-validator-core to 2.35.2

### DIFF
--- a/openapi-validation-core/build.gradle
+++ b/openapi-validation-core/build.gradle
@@ -3,7 +3,7 @@ apply from: "${rootDir}/gradle/publish-module.gradle"
 dependencies {
     api project(':openapi-validation-api')
 
-    implementation 'com.atlassian.oai:swagger-request-validator-core:2.35.1'
+    implementation 'com.atlassian.oai:swagger-request-validator-core:2.35.2'
     constraints {
         implementation('commons-codec:commons-codec:1.16.0') {
             because 'Apache commons-codec before 1.13 is vulnerable to information exposure. See https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/'


### PR DESCRIPTION
Update `swagger-request-validator-core to` to `2.35.2` that contains the two following bug fixes:
- [bugfix: not required and exploded query parameters handling
](https://bitbucket.org/atlassian/swagger-request-validator/pull-requests/391/bugfix-not-required-and-exploded-query)
- [bugfix: Fix path double-normalized if same prefix as base path](https://bitbucket.org/atlassian/swagger-request-validator/pull-requests/390/bugfix-fix-path-double-normalized-if-same)