### PR TITLE
Do not validate HEAD requests

### DIFF
--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelector.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelector.java
@@ -51,12 +51,14 @@ public class DefaultTrafficSelector implements TrafficSelector {
     @Override
     public boolean canRequestBeValidated(RequestMetaData request) {
         return !methodEquals(request.getMethod(), "OPTIONS")
+            && !methodEquals(request.getMethod(), "HEAD")
             && isContentTypeSupported(request.getContentType());
     }
 
     @Override
     public boolean canResponseBeValidated(RequestMetaData request, ResponseMetaData response) {
         return !methodEquals(request.getMethod(), "OPTIONS")
+            && !methodEquals(request.getMethod(), "HEAD")
             && isContentTypeSupported(response.getContentType());
     }
 


### PR DESCRIPTION
Do not validate HEAD requests because they are normally not specified in the openapi specification. They could be specified, but normally we don't specify them as they are the same as GET requests.