### PR TITLE
Send sample-rate and throttling information with startup metric

### DIFF
--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/DefaultMetricsReporter.java
@@ -20,8 +20,15 @@ public class DefaultMetricsReporter implements MetricsReporter {
     }
 
     @Override
-    public void reportStartup(boolean isValidationEnabled) {
-        metricsClient.increment(buildMetricName(".startup"), createTagsForStartup(isValidationEnabled));
+    public void reportStartup(
+        boolean isValidationEnabled,
+        double sampleRate,
+        int validationReportThrottleWaitSeconds
+    ) {
+        metricsClient.increment(
+            buildMetricName(".startup"),
+            createTagsForStartup(isValidationEnabled, sampleRate, validationReportThrottleWaitSeconds)
+        );
     }
 
     @Override
@@ -47,10 +54,16 @@ public class DefaultMetricsReporter implements MetricsReporter {
         return tags.toArray(MetricTag[]::new);
     }
 
-    private MetricTag[] createTagsForStartup(boolean isValidationEnabled) {
+    private MetricTag[] createTagsForStartup(
+        boolean isValidationEnabled,
+        double sampleRate,
+        int validationReportThrottleWaitSeconds
+    ) {
         var tags = new ArrayList<MetricTag>();
 
         tags.add(new MetricTag("validation_enabled", String.valueOf(isValidationEnabled)));
+        tags.add(new MetricTag("sample_rate", String.valueOf(sampleRate)));
+        tags.add(new MetricTag("throttling", String.valueOf(validationReportThrottleWaitSeconds)));
         addAdditionalTags(tags);
 
         return tags.toArray(MetricTag[]::new);

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricsReporter.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricsReporter.java
@@ -5,7 +5,7 @@ import com.getyourguide.openapi.validation.api.model.OpenApiViolation;
 public interface MetricsReporter {
     void reportViolation(OpenApiViolation violation);
 
-    void reportStartup(boolean isValidationEnabled);
+    void reportStartup(boolean isValidationEnabled, double sampleRate, int validationReportThrottleWaitSeconds);
 
     void reportValidationHeartbeat();
 }

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelector.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelector.java
@@ -10,8 +10,6 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public class DefaultTrafficSelector implements TrafficSelector {
 
-    private static final double SAMPLE_RATE_DEFAULT = 0.001; // 1.0 = 100%
-
     private final double sampleRate;
     private final Set<String> excludedPaths;
     private final List<ExcludedHeader> excludedHeaders;
@@ -23,13 +21,13 @@ public class DefaultTrafficSelector implements TrafficSelector {
     }
 
     public DefaultTrafficSelector(
-        Double sampleRate,
+        double sampleRate,
         Set<String> excludedPaths,
         List<ExcludedHeader> excludedHeaders,
         Boolean shouldFailOnRequestViolation,
         Boolean shouldFailOnResponseViolation
     ) {
-        this.sampleRate = sampleRate != null ? sampleRate : SAMPLE_RATE_DEFAULT;
+        this.sampleRate = sampleRate;
         this.excludedPaths = excludedPaths != null ? excludedPaths : Set.of();
         this.excludedHeaders = excludedHeaders != null ? excludedHeaders : Collections.emptyList();
         this.shouldFailOnRequestViolation = shouldFailOnRequestViolation != null ? shouldFailOnRequestViolation : false;

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidationConfiguration.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidationConfiguration.java
@@ -1,0 +1,11 @@
+package com.getyourguide.openapi.validation.core;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class OpenApiRequestValidationConfiguration {
+    private double sampleRate;
+    private int validationReportThrottleWaitSeconds;
+}

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
@@ -32,14 +32,19 @@ public class OpenApiRequestValidator {
         ThreadPoolExecutor threadPoolExecutor,
         ValidationReportHandler validationReportHandler,
         MetricsReporter metricsReporter,
-        OpenApiInteractionValidatorWrapper validator
+        OpenApiInteractionValidatorWrapper validator,
+        OpenApiRequestValidationConfiguration configuration
     ) {
         this.threadPoolExecutor = threadPoolExecutor;
         this.validator = validator;
         this.validationReportHandler = validationReportHandler;
         this.metricsReporter = metricsReporter;
 
-        metricsReporter.reportStartup(validator != null);
+        metricsReporter.reportStartup(
+            validator != null,
+            configuration.getSampleRate(),
+            configuration.getValidationReportThrottleWaitSeconds()
+        );
     }
 
     public boolean isReady() {

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
@@ -36,7 +36,8 @@ public class OpenApiRequestValidatorTest {
             threadPoolExecutor,
             validationReportHandler,
             metricsReporter,
-            validator
+            validator,
+            mock()
         );
     }
 

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
@@ -4,6 +4,7 @@ import static com.getyourguide.openapi.validation.OpenApiValidationApplicationPr
 
 import com.getyourguide.openapi.validation.api.exclusions.ExcludedHeader;
 import com.getyourguide.openapi.validation.api.metrics.MetricTag;
+import com.getyourguide.openapi.validation.core.OpenApiRequestValidationConfiguration;
 import com.getyourguide.openapi.validation.util.CommaSeparatedStringsUtil;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @Setter
 public class OpenApiValidationApplicationProperties {
     public static final String PROPERTY_PREFIX = "openapi.validation";
+    private static final double SAMPLE_RATE_DEFAULT = 0.001; // 1.0 = 100%
 
     private Double sampleRate;
     private String specificationFilePath;
@@ -34,6 +36,14 @@ public class OpenApiValidationApplicationProperties {
     private List<String> excludedHeaders;
     private Boolean shouldFailOnRequestViolation;
     private Boolean shouldFailOnResponseViolation;
+
+    public double getSampleRate() {
+        return sampleRate != null ? sampleRate : SAMPLE_RATE_DEFAULT;
+    }
+
+    public int getValidationReportThrottleWaitSeconds() {
+        return validationReportThrottleWaitSeconds != null ? validationReportThrottleWaitSeconds : 0;
+    }
 
     public List<MetricTag> getValidationReportMetricAdditionalTags() {
         if (validationReportMetricAdditionalTags == null) {
@@ -70,5 +80,12 @@ public class OpenApiValidationApplicationProperties {
             })
             .filter(Objects::nonNull)
             .toList();
+    }
+
+    public OpenApiRequestValidationConfiguration toOpenApiRequestValidationConfiguration() {
+        return OpenApiRequestValidationConfiguration.builder()
+            .sampleRate(getSampleRate())
+            .validationReportThrottleWaitSeconds(getValidationReportThrottleWaitSeconds())
+            .build();
     }
 }

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
@@ -42,8 +42,7 @@ public class LibraryAutoConfiguration {
     @Bean
     @ConditionalOnMissingBean
     public ValidationReportThrottler requestBasedThrottleHelper() {
-        if (properties.getValidationReportThrottleWaitSeconds() == null
-            || properties.getValidationReportThrottleWaitSeconds() == 0) {
+        if (properties.getValidationReportThrottleWaitSeconds() == 0) {
             return new ValidationReportThrottlerNone();
         }
         return new RequestBasedValidationReportThrottler(properties.getValidationReportThrottleWaitSeconds());
@@ -114,7 +113,8 @@ public class LibraryAutoConfiguration {
             validationReportHandler,
             metricsReporter,
             new OpenApiInteractionValidatorFactory()
-                .build(properties.getSpecificationFilePath(), validatorConfiguration)
+                .build(properties.getSpecificationFilePath(), validatorConfiguration),
+            properties.toOpenApiRequestValidationConfiguration()
         );
     }
 }


### PR DESCRIPTION
To allow identifying services quickly by sample-rate and throttling, this adds the sample rate and throttling information to the startup metric. As this is a metric that doesn't change often, this won't be adding much cost in datadog (or similar).