### PR TITLE
change: Ignore unexpected query parameter violation

### DIFF
--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
@@ -90,6 +90,7 @@ public class LibraryAutoConfiguration {
     public ValidatorConfiguration validatorConfiguration() {
         return new ValidatorConfigurationBuilder()
             // .levelResolverLevel("validation.request.body.schema.additionalProperties", LogLevel.IGNORE)
+            .levelResolverLevel("validation.request.parameter.query.unexpected", LogLevel.IGNORE)
             .levelResolverDefaultLevel(
                 properties.getViolationLogLevel() != null ? properties.getViolationLogLevel() : LogLevel.INFO
             )


### PR DESCRIPTION
If a request sends an additional query parameter that is not expected, it normally logs a violation. Additional query params are not really a problem.