### PR TITLE
bugfix: Exclude "matched 2 out of 25" in the oneOf rule

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -14,8 +14,16 @@ public class InternalViolationExclusions {
             || falsePositive400(violation)
             || customViolationExclusions.isExcluded(violation)
             // If it matches more than 1, then we don't want to log a validation error
-            || violation.getMessage().matches(
-            ".*\\[Path '[^']+'] Instance failed to match exactly one schema \\(matched [1-9][0-9]* out of \\d\\).*");
+            || oneOfMatchesMoreThanOneSchema(violation);
+    }
+
+    private static boolean oneOfMatchesMoreThanOneSchema(OpenApiViolation violation) {
+        return (
+            "validation.response.body.schema.oneOf".equals(violation.getRule()) ||
+                "validation.request.body.schema.oneOf".equals(violation.getRule())
+        )
+            && violation.getMessage()
+            .matches(".*Instance failed to match exactly one schema \\(matched [1-9][0-9]* out of \\d+\\).*");
     }
 
     private boolean falsePositive404(OpenApiViolation violation) {

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -13,15 +13,14 @@ public class InternalViolationExclusions {
         return falsePositive404(violation)
             || falsePositive400(violation)
             || customViolationExclusions.isExcluded(violation)
-            // If it matches more than 1, then we don't want to log a validation error
             || oneOfMatchesMoreThanOneSchema(violation);
     }
 
     private static boolean oneOfMatchesMoreThanOneSchema(OpenApiViolation violation) {
         return (
-            "validation.response.body.schema.oneOf".equals(violation.getRule()) ||
-                "validation.request.body.schema.oneOf".equals(violation.getRule())
-        )
+            "validation.response.body.schema.oneOf".equals(violation.getRule())
+                || "validation.request.body.schema.oneOf".equals(violation.getRule())
+            )
             && violation.getMessage()
             .matches(".*Instance failed to match exactly one schema \\(matched [1-9][0-9]* out of \\d+\\).*");
     }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
@@ -55,6 +55,7 @@ public class InternalViolationExclusionsTest {
         when(customViolationExclusions.isExcluded(any())).thenReturn(false);
 
         checkViolationExcluded(OpenApiViolation.builder()
+            .rule("validation.response.body.schema.oneOf")
             .message("[Path '/v1/endpoint'] Instance failed to match exactly one schema (matched 2 out of 4)").build());
     }
 

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
@@ -64,7 +64,7 @@ public class InternalViolationExclusionsTest {
         when(customViolationExclusions.isExcluded(any())).thenReturn(false);
 
         checkViolationExcluded(OpenApiViolation.builder()
-            .rule("validation.response.body.schema.oneOf")
+            .rule("validation.request.body.schema.oneOf")
             .message("[Path '/v1/endpoint'] Instance failed to match exactly one schema (matched 2 out of 24)")
             .build());
     }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
@@ -60,6 +60,16 @@ public class InternalViolationExclusionsTest {
     }
 
     @Test
+    public void testWhenInstanceFailedToMatchExactlyOneWithOneOf24ThenViolationExcluded() {
+        when(customViolationExclusions.isExcluded(any())).thenReturn(false);
+
+        checkViolationExcluded(OpenApiViolation.builder()
+            .rule("validation.response.body.schema.oneOf")
+            .message("[Path '/v1/endpoint'] Instance failed to match exactly one schema (matched 2 out of 24)")
+            .build());
+    }
+
+    @Test
     public void testWhen404ResponseWithApiPathNotSpecifiedThenViolationExcluded() {
         when(customViolationExclusions.isExcluded(any())).thenReturn(false);
 


### PR DESCRIPTION
A violation like the following should have been excluded, but was not:

```
OpenAPI spec validation error [validation.response.body.schema.oneOf]
...

INFO - [Path '/.../0'] Instance failed to match exactly one schema (matched 2 out of 25): 
...
```

Bug: It only worked if `matched 2 out of x` with x being a single number.

This is fixed with this PR switching from just `\d` to `\d+`.