### PR TITLE
Improve logging when there is no validator found for a path

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
@@ -50,7 +50,7 @@ public class MultipleSpecOpenApiInteractionValidatorWrapper implements OpenApiIn
     private static SimpleMessage buildNoValidatorFoundMessage(String path) {
         return new SimpleMessage(
             MESSAGE_KEY_NO_VALIDATOR_FOUND,
-            "No validator found in ValidatorConfiguration for path: " + path,
+            "ValidatorConfiguration has no spec file matching path: " + path,
             ValidationReport.Level.WARN
         );
     }

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
@@ -12,7 +12,7 @@ import lombok.AllArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
 
 public class MultipleSpecOpenApiInteractionValidatorWrapper implements OpenApiInteractionValidatorWrapper {
-    public static final String MESSAGE_KEY_VALIDATOR_FOUND = "zopenapi-validator-java.noValidatorFound";
+    public static final String MESSAGE_KEY_NO_VALIDATOR_FOUND = "openapi-validator-java.noValidatorFound";
     private final List<Pair<Pattern, OpenApiInteractionValidatorWrapper>> validators;
 
     public MultipleSpecOpenApiInteractionValidatorWrapper(
@@ -49,8 +49,8 @@ public class MultipleSpecOpenApiInteractionValidatorWrapper implements OpenApiIn
 
     private static SimpleMessage buildNoValidatorFoundMessage(String path) {
         return new SimpleMessage(
-            MESSAGE_KEY_VALIDATOR_FOUND,
-            "No validator found for path: " + path,
+            MESSAGE_KEY_NO_VALIDATOR_FOUND,
+            "No validator found in ValidatorConfiguration for path: " + path,
             ValidationReport.Level.WARN
         );
     }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
@@ -1,6 +1,6 @@
 package com.getyourguide.openapi.validation.core.validator;
 
-import static com.getyourguide.openapi.validation.core.validator.MultipleSpecOpenApiInteractionValidatorWrapper.MESSAGE_KEY_VALIDATOR_FOUND;
+import static com.getyourguide.openapi.validation.core.validator.MultipleSpecOpenApiInteractionValidatorWrapper.MESSAGE_KEY_NO_VALIDATOR_FOUND;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -52,7 +52,7 @@ public class MultipleSpecOpenApiInteractionValidatorWrapperTest {
         var messages = report.getMessages();
         assertEquals(1, messages.size());
         var message = messages.get(0);
-        assertEquals(MESSAGE_KEY_VALIDATOR_FOUND, message.getKey());
+        assertEquals(MESSAGE_KEY_NO_VALIDATOR_FOUND, message.getKey());
         assertEquals("No validator found for path: /123", message.getMessage());
     }
 

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
@@ -53,7 +53,7 @@ public class MultipleSpecOpenApiInteractionValidatorWrapperTest {
         assertEquals(1, messages.size());
         var message = messages.get(0);
         assertEquals(MESSAGE_KEY_NO_VALIDATOR_FOUND, message.getKey());
-        assertEquals("No validator found for path: /123", message.getMessage());
+        assertEquals("No validator found in ValidatorConfiguration for path: /123", message.getMessage());
     }
 
     private static MockValidatorResult mockValidator() {

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
@@ -53,7 +53,7 @@ public class MultipleSpecOpenApiInteractionValidatorWrapperTest {
         assertEquals(1, messages.size());
         var message = messages.get(0);
         assertEquals(MESSAGE_KEY_NO_VALIDATOR_FOUND, message.getKey());
-        assertEquals("No validator found in ValidatorConfiguration for path: /123", message.getMessage());
+        assertEquals("ValidatorConfiguration has no spec file matching path: /123", message.getMessage());
     }
 
     private static MockValidatorResult mockValidator() {


### PR DESCRIPTION
- `zopenapi-validation-java` -> `openapi-validation-java`: `z` was a mistake and was misleading
- The error message now explains where the validator is searched in