### PR TITLE
Log missing spec file path

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
@@ -36,7 +36,7 @@ public class OpenApiInteractionValidatorFactory {
 
         var specOptional = loadOpenAPISpec(specificationFilePath);
         if (specOptional.isEmpty()) {
-            log.info("OpenAPI spec file could not be found [validation disabled]");
+            log.info("OpenAPI spec file `{}` could not be found [validation disabled]", specificationFilePath);
             return null;
         }
 


### PR DESCRIPTION
If spec file could not be found it would log an error message. This changes the message to also contain the provided path.