### PR TITLE
[Bugfix] Ignore violation operation not allowed with status code 404

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -29,8 +29,11 @@ public class InternalViolationExclusions {
     }
 
     private boolean falsePositive404(OpenApiViolation violation) {
-        return Rules.Request.PATH_MISSING.equals(violation.getRule())
-            && (
+        return
+            (
+                Rules.Request.PATH_MISSING.equals(violation.getRule())
+                || Rules.Request.OPERATION_NOT_ALLOWED.equals(violation.getRule())
+            ) && (
                 violation.getDirection() == Direction.REQUEST
                 || (violation.getDirection() == Direction.RESPONSE && violation.getResponseStatus().orElse(0) == 404)
             );

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -34,8 +34,8 @@ public class InternalViolationExclusions {
                 Rules.Request.PATH_MISSING.equals(violation.getRule())
                 || Rules.Request.OPERATION_NOT_ALLOWED.equals(violation.getRule())
             ) && (
-                violation.getDirection() == Direction.REQUEST
-                || (violation.getDirection() == Direction.RESPONSE && violation.getResponseStatus().orElse(0) == 404)
+                (violation.getDirection() == Direction.REQUEST && violation.getResponseStatus().isEmpty())
+                || violation.getResponseStatus().orElse(0) == 404
             );
     }
 

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
@@ -81,6 +81,29 @@ public class InternalViolationExclusionsTest {
     }
 
     @Test
+    public void when404ResponseWithOperationNotAllowedThenViolationExcluded() {
+        when(customViolationExclusions.isExcluded(any())).thenReturn(false);
+
+        checkViolationExcluded(OpenApiViolation.builder()
+            .direction(Direction.RESPONSE)
+            .rule("validation.request.operation.notAllowed")
+            .responseStatus(404)
+            .message("GET operation not allowed on path '/users'")
+            .build());
+    }
+
+    @Test
+    public void when404RequestWithOperationNotAllowedThenViolationExcluded() {
+        when(customViolationExclusions.isExcluded(any())).thenReturn(false);
+
+        checkViolationExcluded(OpenApiViolation.builder()
+            .direction(Direction.REQUEST)
+            .rule("validation.request.operation.notAllowed")
+            .message("GET operation not allowed on path '/users'")
+            .build());
+    }
+
+    @Test
     public void whenRequestWithApiPathNotSpecifiedThenViolationExcluded() {
         when(customViolationExclusions.isExcluded(any())).thenReturn(false);
 


### PR DESCRIPTION
If there is a request returning 404 that triggers a `validation.request.operation.notAllowed` violation, this should not be logged as a violation.

Reason: 404 is the expected response for a not specified operation.