### PR TITLE
bugfix: exclude 406 status code violations

### DIFF
--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/Rules.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/Rules.java
@@ -9,5 +9,6 @@ public class Rules {
 
     public static class Response {
         public static final String BODY_SCHEMA_ONE_OF = "validation.response.body.schema.oneOf";
+        public static final String STATUS_UNKNOWN = "validation.response.status.unknown";
     }
 }

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -15,6 +15,7 @@ public class InternalViolationExclusions {
         return falsePositive404(violation)
             || falsePositive400(violation)
             || falsePositive405(violation)
+            || falsePositive406(violation)
             || customViolationExclusions.isExcluded(violation)
             || oneOfMatchesMoreThanOneSchema(violation);
     }
@@ -46,5 +47,10 @@ public class InternalViolationExclusions {
     private boolean falsePositive405(OpenApiViolation violation) {
         return violation.getResponseStatus().orElse(0) == 405
             && Rules.Request.OPERATION_NOT_ALLOWED.equals(violation.getRule());
+    }
+
+    private boolean falsePositive406(OpenApiViolation violation) {
+        return violation.getResponseStatus().orElse(0) == 406
+            && Rules.Response.STATUS_UNKNOWN.equals(violation.getRule());
     }
 }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
@@ -145,6 +145,18 @@ public class InternalViolationExclusionsTest {
             .build());
     }
 
+    @Test
+    public void when406ResponseCodeWithStatusUnknownViolationThenViolationExcluded() {
+        when(customViolationExclusions.isExcluded(any())).thenReturn(false);
+
+        checkViolationExcluded(OpenApiViolation.builder()
+            .direction(Direction.RESPONSE)
+            .rule("validation.response.status.unknown")
+            .responseStatus(406)
+            .message("")
+            .build());
+    }
+
     private void checkViolationNotExcluded(OpenApiViolation violation) {
         var isExcluded = violationExclusions.isExcluded(violation);
 


### PR DESCRIPTION
Excludes violations similar to this one:
```
OpenAPI spec validation error [validation.response.status.unknown]
GET https://api.example.com/users
Response Status Code: 406

INFO - Response status 406 not defined for path '/users'.: []
```

**Reason**
If the service returns a 406 this is the expected response if a client asks for something the service can't deliver.