### PR TITLE
NoTicket: Use self-hosted runners instead of GitHub-hosted runners

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    runs-on: [self-hosted, small]
+    runs-on: [self-hosted, java-small]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/check.yml
   publish:
     needs: check
-    runs-on: [self-hosted, small]
+    runs-on: [self-hosted, java-small]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     uses: ./.github/workflows/check.yml
   publish:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -37,7 +37,7 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
   github-release:
     needs: publish
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, small]
     steps:
       - uses: actions/checkout@v3
       - name: Extract release notes


### PR DESCRIPTION
This pull request is to change the CI runner from GitHub-hosted runners (ubuntu-latest) to self-hosted runners. This change is necessary to improve the cost and control over our build environment. Please review our changes and provide your feedback.
