### PR TITLE
feature: Use strict operation path matching

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
@@ -80,6 +80,7 @@ public class OpenApiInteractionValidatorFactory {
                 .withResolveRefs(true)
                 .withResolveCombinators(true) // Inline to avoid problems with allOf
                 .withLevelResolver(buildLevelResolver(levelResolverLevels, levelResolverDefaultLevel))
+                .withStrictOperationPathMatching()
                 .build();
             return new SingleSpecOpenApiInteractionValidatorWrapper(validator);
         } catch (Throwable e) {


### PR DESCRIPTION
Enable strict operation path matching that was added in swagger-request-validator here: https://bitbucket.org/atlassian/swagger-request-validator/pull-requests/405/bugfix-make-ending-slash-strict