### PR TITLE
bugfix: do not report violation on blocked request

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidationConfiguration.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidationConfiguration.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class OpenApiRequestValidationConfiguration {
     private double sampleRate;
     private int validationReportThrottleWaitSeconds;
+    private boolean shouldFailOnRequestViolation;
 }

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
@@ -88,7 +88,7 @@ public class OpenApiValidationApplicationProperties {
         return OpenApiRequestValidationConfiguration.builder()
             .sampleRate(getSampleRate())
             .validationReportThrottleWaitSeconds(getValidationReportThrottleWaitSeconds())
-            .shouldFailOnRequestViolation(getShouldFailOnRequestViolation())
+            .shouldFailOnRequestViolation(getShouldFailOnRequestViolation() != null && getShouldFailOnRequestViolation())
             .build();
     }
 }

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
@@ -88,6 +88,7 @@ public class OpenApiValidationApplicationProperties {
         return OpenApiRequestValidationConfiguration.builder()
             .sampleRate(getSampleRate())
             .validationReportThrottleWaitSeconds(getValidationReportThrottleWaitSeconds())
+            .shouldFailOnRequestViolation(getShouldFailOnRequestViolation())
             .build();
     }
 }

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/factory/ContentCachingWrapperFactory.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/factory/ContentCachingWrapperFactory.java
@@ -1,19 +1,19 @@
 package com.getyourguide.openapi.validation.factory;
 
+import com.getyourguide.openapi.validation.filter.MultiReadHttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import javax.annotation.Nullable;
-import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 import org.springframework.web.util.WebUtils;
 
 public class ContentCachingWrapperFactory {
-    public ContentCachingRequestWrapper buildContentCachingRequestWrapper(HttpServletRequest request) {
-        if (request instanceof ContentCachingRequestWrapper) {
-            return (ContentCachingRequestWrapper) request;
+    public MultiReadHttpServletRequestWrapper buildContentCachingRequestWrapper(HttpServletRequest request) {
+        if (request instanceof MultiReadHttpServletRequestWrapper) {
+            return (MultiReadHttpServletRequestWrapper) request;
         }
 
-        return new ContentCachingRequestWrapper(request);
+        return new MultiReadHttpServletRequestWrapper(request);
     }
 
     public ContentCachingResponseWrapper buildContentCachingResponseWrapper(HttpServletResponse response) {
@@ -26,12 +26,12 @@ public class ContentCachingWrapperFactory {
     }
 
     @Nullable
-    public ContentCachingResponseWrapper getCachingResponse(final HttpServletResponse response) {
-        return WebUtils.getNativeResponse(response, ContentCachingResponseWrapper.class);
+    public MultiReadHttpServletRequestWrapper getCachingRequest(HttpServletRequest request) {
+        return request instanceof MultiReadHttpServletRequestWrapper ? (MultiReadHttpServletRequestWrapper) request : null;
     }
 
     @Nullable
-    public ContentCachingRequestWrapper getCachingRequest(HttpServletRequest request) {
-        return request instanceof ContentCachingRequestWrapper ? (ContentCachingRequestWrapper) request : null;
+    public ContentCachingResponseWrapper getCachingResponse(final HttpServletResponse response) {
+        return WebUtils.getNativeResponse(response, ContentCachingResponseWrapper.class);
     }
 }

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/factory/ContentCachingWrapperFactory.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/factory/ContentCachingWrapperFactory.java
@@ -1,6 +1,6 @@
 package com.getyourguide.openapi.validation.factory;
 
-import com.getyourguide.openapi.validation.filter.MultiReadHttpServletRequestWrapper;
+import com.getyourguide.openapi.validation.filter.MultiReadContentCachingRequestWrapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import javax.annotation.Nullable;
@@ -8,12 +8,12 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 import org.springframework.web.util.WebUtils;
 
 public class ContentCachingWrapperFactory {
-    public MultiReadHttpServletRequestWrapper buildContentCachingRequestWrapper(HttpServletRequest request) {
-        if (request instanceof MultiReadHttpServletRequestWrapper) {
-            return (MultiReadHttpServletRequestWrapper) request;
+    public MultiReadContentCachingRequestWrapper buildContentCachingRequestWrapper(HttpServletRequest request) {
+        if (request instanceof MultiReadContentCachingRequestWrapper) {
+            return (MultiReadContentCachingRequestWrapper) request;
         }
 
-        return new MultiReadHttpServletRequestWrapper(request);
+        return new MultiReadContentCachingRequestWrapper(request);
     }
 
     public ContentCachingResponseWrapper buildContentCachingResponseWrapper(HttpServletResponse response) {
@@ -26,8 +26,8 @@ public class ContentCachingWrapperFactory {
     }
 
     @Nullable
-    public MultiReadHttpServletRequestWrapper getCachingRequest(HttpServletRequest request) {
-        return request instanceof MultiReadHttpServletRequestWrapper ? (MultiReadHttpServletRequestWrapper) request : null;
+    public MultiReadContentCachingRequestWrapper getCachingRequest(HttpServletRequest request) {
+        return request instanceof MultiReadContentCachingRequestWrapper ? (MultiReadContentCachingRequestWrapper) request : null;
     }
 
     @Nullable

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/MultiReadHttpServletRequestWrapper.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/MultiReadHttpServletRequestWrapper.java
@@ -1,0 +1,81 @@
+package com.getyourguide.openapi.validation.filter;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import org.apache.tomcat.util.http.fileupload.IOUtils;
+
+/**
+ * A class to provide the ability to read a {@link jakarta.servlet.ServletRequest}'s body multiple
+ * times. via https://stackoverflow.com/a/36619972/2257038 and https://stackoverflow.com/a/30748533/2257038
+ */
+public class MultiReadHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+    private ByteArrayOutputStream cachedBytes;
+
+    /**
+     * Construct a new multi-read wrapper.
+     *
+     * @param request to wrap around
+     */
+    public MultiReadHttpServletRequestWrapper(HttpServletRequest request) {
+        super(request);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() throws IOException {
+        if (cachedBytes == null) {
+            cacheInputStream();
+        }
+
+        return new CachedServletInputStream(cachedBytes.toByteArray());
+    }
+
+    @Override
+    public BufferedReader getReader() throws IOException {
+        return new BufferedReader(new InputStreamReader(getInputStream()));
+    }
+
+    private void cacheInputStream() throws IOException {
+        /* Cache the inputstream in order to read it multiple times. For
+         * convenience, I use apache.commons IOUtils
+         */
+        cachedBytes = new ByteArrayOutputStream();
+        IOUtils.copy(super.getInputStream(), cachedBytes);
+    }
+
+    /* An inputstream which reads the cached request body */
+    private static class CachedServletInputStream extends ServletInputStream {
+        private final ByteArrayInputStream buffer;
+
+        public CachedServletInputStream(byte[] contents) {
+            this.buffer = new ByteArrayInputStream(contents);
+        }
+
+        @Override
+        public int read() throws IOException {
+            return buffer.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+            return buffer.available() == 0;
+        }
+
+        @Override
+        public boolean isReady() {
+            return true;
+        }
+
+        @Override
+        public void setReadListener(ReadListener listener) {
+            throw new UnsupportedOperationException("Not implemented");
+        }
+    }
+}

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
@@ -115,6 +115,8 @@ public class OpenApiValidationInterceptor implements AsyncHandlerInterceptor {
             );
             // Note: validateResponseResult will always be null on ASYNC
             if (validateResponseResult == ValidationResult.INVALID) {
+                response.reset();
+                response.setStatus(500);
                 throw new ResponseStatusException(HttpStatusCode.valueOf(500), "Response validation failed");
             }
         }

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
@@ -9,15 +9,16 @@ import com.getyourguide.openapi.validation.factory.ContentCachingWrapperFactory;
 import com.getyourguide.openapi.validation.factory.ServletMetaDataFactory;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.util.StreamUtils;
 import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.AsyncHandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
-import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 @Slf4j
@@ -126,7 +127,7 @@ public class OpenApiValidationInterceptor implements AsyncHandlerInterceptor {
     }
 
     private ValidationResult validateRequest(
-        ContentCachingRequestWrapper request,
+        MultiReadHttpServletRequestWrapper request,
         RequestMetaData requestMetaData,
         @Nullable ResponseMetaData responseMetaData,
         RunType runType
@@ -137,15 +138,21 @@ public class OpenApiValidationInterceptor implements AsyncHandlerInterceptor {
             return ValidationResult.NOT_APPLICABLE;
         }
 
-        var requestBody = request.getContentType() != null
-            ? new String(request.getContentAsByteArray(), StandardCharsets.UTF_8)
-            : null;
+        var requestBody = request.getContentType() != null ? readBodyCatchingException(request) : null;
 
         if (runType == RunType.ASYNC) {
             validator.validateRequestObjectAsync(requestMetaData, responseMetaData, requestBody);
             return ValidationResult.NOT_APPLICABLE;
         } else {
             return validator.validateRequestObject(requestMetaData, requestBody);
+        }
+    }
+
+    private static String readBodyCatchingException(MultiReadHttpServletRequestWrapper request) {
+        try {
+            return StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return null;
         }
     }
 

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
@@ -127,7 +127,7 @@ public class OpenApiValidationInterceptor implements AsyncHandlerInterceptor {
     }
 
     private ValidationResult validateRequest(
-        MultiReadHttpServletRequestWrapper request,
+        MultiReadContentCachingRequestWrapper request,
         RequestMetaData requestMetaData,
         @Nullable ResponseMetaData responseMetaData,
         RunType runType
@@ -148,7 +148,7 @@ public class OpenApiValidationInterceptor implements AsyncHandlerInterceptor {
         }
     }
 
-    private static String readBodyCatchingException(MultiReadHttpServletRequestWrapper request) {
+    private static String readBodyCatchingException(MultiReadContentCachingRequestWrapper request) {
         try {
             return StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/BaseFilterTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/BaseFilterTest.java
@@ -50,7 +50,7 @@ public class BaseFilterTest {
     }
 
     protected MockSetupData mockSetup(MockConfiguration configuration) {
-        var request = mock(MultiReadHttpServletRequestWrapper.class);
+        var request = mock(MultiReadContentCachingRequestWrapper.class);
         var response = mock(ContentCachingResponseWrapper.class);
         var cachingRequest = mockContentCachingRequest(request, configuration);
         var cachingResponse = mockContentCachingResponse(response, configuration);
@@ -101,11 +101,11 @@ public class BaseFilterTest {
         return cachingResponse;
     }
 
-    private MultiReadHttpServletRequestWrapper mockContentCachingRequest(
+    private MultiReadContentCachingRequestWrapper mockContentCachingRequest(
         HttpServletRequest request,
         MockConfiguration configuration
     ) {
-        var cachingRequest = mock(MultiReadHttpServletRequestWrapper.class);
+        var cachingRequest = mock(MultiReadContentCachingRequestWrapper.class);
         when(contentCachingWrapperFactory.buildContentCachingRequestWrapper(request)).thenReturn(cachingRequest);
         if (configuration.requestBody != null) {
             try {

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/BaseFilterTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/BaseFilterTest.java
@@ -16,11 +16,13 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import lombok.Builder;
 import org.mockito.Mockito;
-import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.mock.web.DelegatingServletInputStream;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
 public class BaseFilterTest {
@@ -48,14 +50,11 @@ public class BaseFilterTest {
     }
 
     protected MockSetupData mockSetup(MockConfiguration configuration) {
-        var request = mock(ContentCachingRequestWrapper.class);
+        var request = mock(MultiReadHttpServletRequestWrapper.class);
         var response = mock(ContentCachingResponseWrapper.class);
         var cachingRequest = mockContentCachingRequest(request, configuration);
         var cachingResponse = mockContentCachingResponse(response, configuration);
         mockRequestAttributes(request, cachingRequest);
-
-        when(request.getContentType()).thenReturn("application/json");
-        when(request.getContentAsByteArray()).thenReturn(configuration.requestBody.getBytes(StandardCharsets.UTF_8));
 
         when(response.getContentType()).thenReturn("application/json");
         when(response.getContentAsByteArray()).thenReturn(configuration.responseBody.getBytes(StandardCharsets.UTF_8));
@@ -102,16 +101,24 @@ public class BaseFilterTest {
         return cachingResponse;
     }
 
-    private ContentCachingRequestWrapper mockContentCachingRequest(
+    private MultiReadHttpServletRequestWrapper mockContentCachingRequest(
         HttpServletRequest request,
         MockConfiguration configuration
     ) {
-        var cachingRequest = mock(ContentCachingRequestWrapper.class);
+        var cachingRequest = mock(MultiReadHttpServletRequestWrapper.class);
         when(contentCachingWrapperFactory.buildContentCachingRequestWrapper(request)).thenReturn(cachingRequest);
-        if (configuration.responseBody != null) {
-            when(cachingRequest.getContentType()).thenReturn("application/json");
-            when(cachingRequest.getContentAsByteArray())
-                .thenReturn(configuration.requestBody.getBytes(StandardCharsets.UTF_8));
+        if (configuration.requestBody != null) {
+            try {
+                var sourceStream = new ByteArrayInputStream(configuration.requestBody.getBytes(StandardCharsets.UTF_8));
+                when(request.getContentType()).thenReturn("application/json");
+                when(request.getInputStream()).thenReturn(new DelegatingServletInputStream(sourceStream));
+
+                sourceStream = new ByteArrayInputStream(configuration.requestBody.getBytes(StandardCharsets.UTF_8));
+                when(cachingRequest.getContentType()).thenReturn("application/json");
+                when(cachingRequest.getInputStream()).thenReturn(new DelegatingServletInputStream(sourceStream));
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
         }
         return cachingRequest;
     }

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -1,0 +1,71 @@
+package com.getyourguide.openapi.validation.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.getyourguide.openapi.validation.test.TestViolationLogger;
+import java.util.Optional;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+    "openapi.validation.should-fail-on-request-violation=true",
+    "openapi.validation.should-fail-on-response-violation=true",
+})
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+public class FailOnViolationIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TestViolationLogger openApiViolationLogger;
+
+    @BeforeEach
+    public void setup() {
+        openApiViolationLogger.clearViolations();
+    }
+
+    @Test
+    public void whenInvalidRequestThenReturn400AndNoViolationLogged() throws Exception {
+        mockMvc.perform(post("/test").content("{ \"value\": 1 }").contentType(MediaType.APPLICATION_JSON))
+            .andExpectAll(
+                status().is4xxClientError(),
+                content().string(Matchers.blankOrNullString())
+            );
+        Thread.sleep(100);
+
+        assertEquals(0, openApiViolationLogger.getViolations().size());
+
+        // TODO check that controller did not execute (inject controller here and have addition method to check & clear at setup)
+        // TODO check that something else gets logged?
+    }
+
+    @Test
+    public void whenInvalidResponseThenReturn500AndViolationLogged() throws Exception {
+        mockMvc.perform(get("/test").queryParam("value", "invalid-response-value!"))
+            .andExpectAll(
+                status().is5xxServerError(),
+                content().string(Matchers.blankOrNullString())
+            );
+        Thread.sleep(100);
+
+        assertEquals(1, openApiViolationLogger.getViolations().size());
+        var violation = openApiViolationLogger.getViolations().get(0);
+        assertEquals("validation.response.body.schema.pattern", violation.getRule());
+        assertEquals(Optional.of(200), violation.getResponseStatus());
+        assertEquals(Optional.of("/value"), violation.getInstance());
+    }
+}

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -42,10 +42,10 @@ public class FailOnViolationIntegrationTest {
     @Test
     public void whenValidRequestThenReturnSuccessfully() throws Exception {
         mockMvc.perform(post("/test")
-                .content("{ \"value\": \"test\", \"responseStatusCode\": 200 }").contentType(MediaType.APPLICATION_JSON))
+                .content("{ \"value\": \"testing\", \"responseStatusCode\": 200 }").contentType(MediaType.APPLICATION_JSON))
             .andExpectAll(
                 status().isOk(),
-                jsonPath("$.value").value("test")
+                jsonPath("$.value").value("testing")
             );
         Thread.sleep(100);
 

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.getyourguide.openapi.validation.test.TestViolationLogger;
@@ -36,6 +37,19 @@ public class FailOnViolationIntegrationTest {
     @BeforeEach
     public void setup() {
         openApiViolationLogger.clearViolations();
+    }
+
+    @Test
+    public void whenValidRequestThenReturnSuccessfully() throws Exception {
+        mockMvc.perform(post("/test")
+                .content("{ \"value\": \"test\", \"responseStatusCode\": 200 }").contentType(MediaType.APPLICATION_JSON))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.value").value("test")
+            );
+        Thread.sleep(100);
+
+        assertEquals(0, openApiViolationLogger.getViolations().size());
     }
 
     @Test

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -1,12 +1,16 @@
 package com.getyourguide.openapi.validation.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.getyourguide.openapi.validation.integration.controller.DefaultRestController;
 import com.getyourguide.openapi.validation.test.TestViolationLogger;
 import java.util.Optional;
 import org.hamcrest.Matchers;
@@ -16,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -34,6 +39,9 @@ public class FailOnViolationIntegrationTest {
     @Autowired
     private TestViolationLogger openApiViolationLogger;
 
+    @SpyBean
+    private DefaultRestController defaultRestController;
+
     @BeforeEach
     public void setup() {
         openApiViolationLogger.clearViolations();
@@ -50,6 +58,7 @@ public class FailOnViolationIntegrationTest {
         Thread.sleep(100);
 
         assertEquals(0, openApiViolationLogger.getViolations().size());
+        verify(defaultRestController).postTest(any());
     }
 
     @Test
@@ -62,8 +71,7 @@ public class FailOnViolationIntegrationTest {
         Thread.sleep(100);
 
         assertEquals(0, openApiViolationLogger.getViolations().size());
-
-        // TODO check that controller did not execute (inject controller here and have addition method to check & clear at setup)
+        verify(defaultRestController, never()).postTest(any());
         // TODO check that something else gets logged?
     }
 
@@ -81,5 +89,6 @@ public class FailOnViolationIntegrationTest {
         assertEquals("validation.response.body.schema.pattern", violation.getRule());
         assertEquals(Optional.of(200), violation.getResponseStatus());
         assertEquals(Optional.of("/value"), violation.getInstance());
+        verify(defaultRestController).getTest(any(), any(), any());
     }
 }

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/OpenApiValidationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/OpenApiValidationIntegrationTest.java
@@ -123,8 +123,6 @@ public class OpenApiValidationIntegrationTest {
         assertEquals(0, openApiViolationLogger.getViolations().size());
     }
 
-    // TODO Add test that fails on request violation immediately (maybe needs separate test class & setup) should not log violation
-
     @Nullable
     private OpenApiViolation getViolationByRule(List<OpenApiViolation> violations, String rule) {
         return violations.stream()

--- a/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilter.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilter.java
@@ -88,18 +88,18 @@ public class OpenApiValidationWebFilter implements WebFilter {
         if (requestDecorated.getHeaders().containsKey("Content-Type") && requestDecorated.getHeaders().containsKey("Content-Length")) {
             requestDecorated.setOnBodyCachedListener(() -> {
                 var validateRequestResult = validateRequest(requestDecorated, requestMetaData, null, RunType.SYNC);
-                throwStatusExceptionOnViolation(validateRequestResult, "Request validation failed");
+                throwStatusExceptionOnViolation(validateRequestResult, 400, "Request validation failed");
             });
         } else {
             var validateRequestResult = validateRequest(requestDecorated, requestMetaData, null, RunType.SYNC);
-            throwStatusExceptionOnViolation(validateRequestResult, "Request validation failed");
+            throwStatusExceptionOnViolation(validateRequestResult, 400, "Request validation failed");
         }
         return true;
     }
 
-    private static void throwStatusExceptionOnViolation(ValidationResult validateRequestResult, String message) {
+    private static void throwStatusExceptionOnViolation(ValidationResult validateRequestResult, int statusCode,  String message) {
         if (validateRequestResult == ValidationResult.INVALID) {
-            throw new ResponseStatusException(HttpStatus.valueOf(400), message);
+            throw new ResponseStatusException(HttpStatus.valueOf(statusCode), message);
         }
     }
 
@@ -123,7 +123,7 @@ public class OpenApiValidationWebFilter implements WebFilter {
                 responseDecorated.getCachedBody(),
                 RunType.SYNC
             );
-            throwStatusExceptionOnViolation(validateResponseResult, "Response validation failed");
+            throwStatusExceptionOnViolation(validateResponseResult, 500, "Response validation failed");
         });
         return true;
     }

--- a/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilter.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilter.java
@@ -52,19 +52,19 @@ public class OpenApiValidationWebFilter implements WebFilter {
 
         var serverWebExchange = exchange.mutate().request(requestDecorated).response(responseDecorated).build();
 
-        var alreadyDidRequestValidation = validateRequestWithFailOnViolation(requestMetaData, requestDecorated);
-        var alreadyDidResponseValidation = validateResponseWithFailOnViolation(requestMetaData, responseDecorated);
-
-        return chain.filter(serverWebExchange)
+        final var alreadyDidValidation = new AlreadyDidValidation();
+        alreadyDidValidation.response = validateResponseWithFailOnViolation(requestMetaData, responseDecorated);
+        return optionalValidateRequestWithFailOnViolation(requestMetaData, requestDecorated, alreadyDidValidation)
+            .flatMap(dataBuffer -> chain.filter(serverWebExchange))
             .doFinally(signalType -> {
                 // Note: Errors are not handled here. They could be handled with SignalType.ON_ERROR, but then the response body can't be accessed.
                 //       Reason seems to be that those don't use the decorated response that is set here, but use the previous response object.
                 if (signalType == SignalType.ON_COMPLETE) {
                     var responseMetaData = metaDataFactory.buildResponseMetaData(responseDecorated);
-                    if (!alreadyDidRequestValidation) {
+                    if (!alreadyDidValidation.request) {
                         validateRequest(requestDecorated, requestMetaData, responseMetaData, RunType.ASYNC);
                     }
-                    if (!alreadyDidResponseValidation) {
+                    if (!alreadyDidValidation.response) {
                         validateResponse(
                             requestMetaData, responseMetaData, responseDecorated.getCachedBody(), RunType.ASYNC);
                     }
@@ -72,32 +72,27 @@ public class OpenApiValidationWebFilter implements WebFilter {
             });
     }
 
-    /**
-     * Validate request and fail on violation if configured to do so.
-     *
-     * @return true if validation is done as part of this method
-     */
-    private boolean validateRequestWithFailOnViolation(
+    private Mono<AlreadyDidValidation> optionalValidateRequestWithFailOnViolation(
         RequestMetaData requestMetaData,
-        BodyCachingServerHttpRequestDecorator requestDecorated
+        BodyCachingServerHttpRequestDecorator request,
+        AlreadyDidValidation alreadyDidValidation
     ) {
-        if (!trafficSelector.shouldFailOnRequestViolation(requestMetaData)) {
-            return false;
+        if (!trafficSelector.shouldFailOnRequestViolation(requestMetaData)
+            || !request.getHeaders().containsKey("Content-Type")
+            || !request.getHeaders().containsKey("Content-Length")) {
+            return Mono.just(alreadyDidValidation);
         }
 
-        if (requestDecorated.getHeaders().containsKey("Content-Type") && requestDecorated.getHeaders().containsKey("Content-Length")) {
-            requestDecorated.setOnBodyCachedListener(() -> {
-                var validateRequestResult = validateRequest(requestDecorated, requestMetaData, null, RunType.SYNC);
+        return request.consumeRequestBody()
+            .map((optionalRequestBody) -> {
+                var validateRequestResult = validateRequest(request, requestMetaData, null, RunType.SYNC);
                 throwStatusExceptionOnViolation(validateRequestResult, 400, "Request validation failed");
+                alreadyDidValidation.request = true;
+                return alreadyDidValidation;
             });
-        } else {
-            var validateRequestResult = validateRequest(requestDecorated, requestMetaData, null, RunType.SYNC);
-            throwStatusExceptionOnViolation(validateRequestResult, 400, "Request validation failed");
-        }
-        return true;
     }
 
-    private static void throwStatusExceptionOnViolation(ValidationResult validateRequestResult, int statusCode,  String message) {
+    private static void throwStatusExceptionOnViolation(ValidationResult validateRequestResult, int statusCode, String message) {
         if (validateRequestResult == ValidationResult.INVALID) {
             throw new ResponseStatusException(HttpStatus.valueOf(statusCode), message);
         }
@@ -165,4 +160,9 @@ public class OpenApiValidationWebFilter implements WebFilter {
     }
 
     private enum RunType { SYNC, ASYNC }
+
+    private static class AlreadyDidValidation {
+        private boolean request = false;
+        private boolean response = false;
+    }
 }

--- a/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
@@ -3,13 +3,16 @@ package com.getyourguide.openapi.validation.filter.decorator;
 import com.getyourguide.openapi.validation.api.model.RequestMetaData;
 import com.getyourguide.openapi.validation.api.selector.TrafficSelector;
 import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.http.server.reactive.ServerHttpRequestDecorator;
 import org.springframework.lang.NonNull;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import reactor.core.publisher.SignalType;
 
 public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDecorator {
@@ -21,6 +24,7 @@ public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDeco
 
     @Getter
     private String cachedBody;
+    private boolean bodyCached = false;
 
     public BodyCachingServerHttpRequestDecorator(
         ServerHttpRequest delegate,
@@ -32,9 +36,26 @@ public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDeco
         this.requestMetaData = requestMetaData;
     }
 
+    public Mono<String> consumeRequestBody() {
+        return Mono.from(getBody().collectList())
+            .map(dataBuffers ->
+                dataBuffers.stream()
+                    .map(dataBuffer -> dataBuffer.toString(StandardCharsets.UTF_8))
+                    .collect(Collectors.joining(""))
+            );
+    }
+
     @Override
     @NonNull
     public Flux<DataBuffer> getBody() {
+        if (bodyCached) {
+            var bufferFactory = new DefaultDataBufferFactory();
+            var bytes = cachedBody.getBytes(StandardCharsets.UTF_8);
+            var buffer = bufferFactory.allocateBuffer(bytes.length);
+            buffer.write(bytes);
+            return Flux.just(buffer);
+        }
+
         if (!trafficSelector.canRequestBeValidated(requestMetaData)) {
             return super.getBody();
         }
@@ -49,6 +70,7 @@ public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDeco
             .doFinally(signalType -> {
                 if (signalType == SignalType.ON_COMPLETE && onBodyCachedListener != null) {
                     onBodyCachedListener.run();
+                    bodyCached = true;
                 }
             });
     }

--- a/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/main/java/com/getyourguide/openapi/validation/filter/decorator/BodyCachingServerHttpRequestDecorator.java
@@ -5,7 +5,6 @@ import com.getyourguide.openapi.validation.api.selector.TrafficSelector;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -18,9 +17,6 @@ import reactor.core.publisher.SignalType;
 public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDecorator {
     private final TrafficSelector trafficSelector;
     private final RequestMetaData requestMetaData;
-
-    @Setter
-    private Runnable onBodyCachedListener;
 
     @Getter
     private String cachedBody;
@@ -68,8 +64,7 @@ public class BodyCachingServerHttpRequestDecorator extends ServerHttpRequestDeco
                 cachedBody += dataBuffer.toString(StandardCharsets.UTF_8);
             })
             .doFinally(signalType -> {
-                if (signalType == SignalType.ON_COMPLETE && onBodyCachedListener != null) {
-                    onBodyCachedListener.run();
+                if (signalType == SignalType.ON_COMPLETE) {
                     bodyCached = true;
                 }
             });

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilterTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilterTest.java
@@ -132,7 +132,9 @@ class OpenApiValidationWebFilterTest {
         when(validator.validateRequestObject(eq(mockData.requestMetaData), any(), eq(REQUEST_BODY)))
             .thenReturn(ValidationResult.INVALID);
 
-        assertThrows(ResponseStatusException.class, () -> webFilter.filter(mockData.exchange, mockData.chain));
+        StepVerifier.create(webFilter.filter(mockData.exchange, mockData.chain))
+            .expectErrorMatches(throwable -> throwable instanceof ResponseStatusException)
+            .verify();
 
         verifyChainNotCalled(mockData.chain);
         verifyRequestValidatedSync(mockData);
@@ -226,6 +228,7 @@ class OpenApiValidationWebFilterTest {
             .thenReturn(decoratedRequest);
         when(decoratedRequest.getHeaders()).thenReturn(buildHeadersForBody(configuration.requestBody));
         when(decoratedRequest.getCachedBody()).thenReturn(configuration.requestBody);
+        when(decoratedRequest.consumeRequestBody()).thenReturn(Mono.just(configuration.requestBody));
         if (configuration.requestBody != null) {
             doAnswer(invocation -> {
                 invocation.getArgument(0, Runnable.class).run();

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilterTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/filter/OpenApiValidationWebFilterTest.java
@@ -229,12 +229,6 @@ class OpenApiValidationWebFilterTest {
         when(decoratedRequest.getHeaders()).thenReturn(buildHeadersForBody(configuration.requestBody));
         when(decoratedRequest.getCachedBody()).thenReturn(configuration.requestBody);
         when(decoratedRequest.consumeRequestBody()).thenReturn(Mono.just(configuration.requestBody));
-        if (configuration.requestBody != null) {
-            doAnswer(invocation -> {
-                invocation.getArgument(0, Runnable.class).run();
-                return null;
-            }).when(decoratedRequest).setOnBodyCachedListener(any());
-        }
 
         var decoratedResponse = mock(BodyCachingServerHttpResponseDecorator.class);
         when(decoratorBuilder.buildBodyCachingServerHttpResponseDecorator(response, requestMetaData))

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -40,6 +40,21 @@ public class FailOnViolationIntegrationTest {
     }
 
     @Test
+    public void whenValidRequestThenReturnSuccessfully() throws Exception {
+        webTestClient
+            .post().uri("/test")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{ \"value\": \"test\", \"responseStatusCode\": 200 }")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody().jsonPath("$.value").isEqualTo("test");
+        Thread.sleep(100);
+
+        assertEquals(0, openApiViolationLogger.getViolations().size());
+    }
+
+    @Test
     public void whenInvalidRequestThenReturn400AndNoViolationLogged() throws Exception {
         webTestClient
             .post().uri("/test")

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.getyourguide.openapi.validation.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.getyourguide.openapi.validation.test.TestViolationLogger;
+import java.util.Optional;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(properties = {
+    "openapi.validation.should-fail-on-request-violation=true",
+    "openapi.validation.should-fail-on-response-violation=true",
+})
+@AutoConfigureMockMvc
+@ExtendWith(SpringExtension.class)
+public class FailOnViolationIntegrationTest {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Autowired
+    private TestViolationLogger openApiViolationLogger;
+
+    @BeforeEach
+    public void setup() {
+        openApiViolationLogger.clearViolations();
+    }
+
+    @Test
+    public void whenInvalidRequestThenReturn400AndNoViolationLogged() throws Exception {
+        webTestClient
+            .post().uri("/test")
+            .accept(MediaType.APPLICATION_JSON)
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{ \"value\": 1 }")
+            .exchange()
+            .expectStatus().is4xxClientError()
+            .expectBody().isEmpty();
+        Thread.sleep(100);
+
+        assertEquals(0, openApiViolationLogger.getViolations().size());
+
+        // TODO check that controller did not execute (inject controller here and have addition method to check & clear at setup)
+        // TODO check that something else gets logged?
+    }
+
+    @Test
+    public void whenInvalidResponseThenReturn500AndViolationLogged() throws Exception {
+        webTestClient
+            .get().uri("/test?value=invalid-response-value!")
+            .accept(MediaType.APPLICATION_JSON)
+            .exchange()
+            .expectStatus().is5xxServerError()
+            .expectBody().isEmpty();
+        Thread.sleep(100);
+
+        assertEquals(1, openApiViolationLogger.getViolations().size());
+        var violation = openApiViolationLogger.getViolations().get(0);
+        assertEquals("validation.response.body.schema.pattern", violation.getRule());
+        assertEquals(Optional.of(200), violation.getResponseStatus());
+        assertEquals(Optional.of("/value"), violation.getInstance());
+    }
+}

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -1,14 +1,9 @@
 package com.getyourguide.openapi.validation.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.getyourguide.openapi.validation.test.TestViolationLogger;
 import java.util.Optional;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(properties = {
     "openapi.validation.should-fail-on-request-violation=true",

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -82,7 +82,10 @@ public class FailOnViolationIntegrationTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus().is5xxServerError()
-            .expectBody().isEmpty();
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(500)
+            .jsonPath("$.path").isEqualTo("/test")
+            .jsonPath("$.error").isEqualTo("Internal Server Error");
         Thread.sleep(100);
 
         assertEquals(1, openApiViolationLogger.getViolations().size());
@@ -90,6 +93,6 @@ public class FailOnViolationIntegrationTest {
         assertEquals("validation.response.body.schema.pattern", violation.getRule());
         assertEquals(Optional.of(200), violation.getResponseStatus());
         assertEquals(Optional.of("/value"), violation.getInstance());
-        verify(defaultRestController).postTest(any(), any());
+        verify(defaultRestController).getTest(any(), any(), any(), any());
     }
 }

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -66,7 +66,10 @@ public class FailOnViolationIntegrationTest {
             .bodyValue("{ \"value\": 1 }")
             .exchange()
             .expectStatus().is4xxClientError()
-            .expectBody().isEmpty();
+            .expectBody()
+            .jsonPath("$.status").isEqualTo(400)
+            .jsonPath("$.path").isEqualTo("/test")
+            .jsonPath("$.error").isEqualTo("Bad Request");
         Thread.sleep(100);
 
         assertEquals(0, openApiViolationLogger.getViolations().size());

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -1,7 +1,11 @@
 package com.getyourguide.openapi.validation.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
+import com.getyourguide.openapi.validation.integration.controller.DefaultRestController;
 import com.getyourguide.openapi.validation.test.TestViolationLogger;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -27,6 +32,9 @@ public class FailOnViolationIntegrationTest {
 
     @Autowired
     private TestViolationLogger openApiViolationLogger;
+
+    @SpyBean
+    private DefaultRestController defaultRestController;
 
     @BeforeEach
     public void setup() {
@@ -46,6 +54,7 @@ public class FailOnViolationIntegrationTest {
         Thread.sleep(100);
 
         assertEquals(0, openApiViolationLogger.getViolations().size());
+        verify(defaultRestController).postTest(any(), any());
     }
 
     @Test
@@ -61,8 +70,8 @@ public class FailOnViolationIntegrationTest {
         Thread.sleep(100);
 
         assertEquals(0, openApiViolationLogger.getViolations().size());
+        verify(defaultRestController, never()).postTest(any(), any());
 
-        // TODO check that controller did not execute (inject controller here and have addition method to check & clear at setup)
         // TODO check that something else gets logged?
     }
 
@@ -81,5 +90,6 @@ public class FailOnViolationIntegrationTest {
         assertEquals("validation.response.body.schema.pattern", violation.getRule());
         assertEquals(Optional.of(200), violation.getResponseStatus());
         assertEquals(Optional.of("/value"), violation.getInstance());
+        verify(defaultRestController).postTest(any(), any());
     }
 }

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/FailOnViolationIntegrationTest.java
@@ -39,10 +39,10 @@ public class FailOnViolationIntegrationTest {
             .post().uri("/test")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("{ \"value\": \"test\", \"responseStatusCode\": 200 }")
+            .bodyValue("{ \"value\": \"testing\", \"responseStatusCode\": 200 }")
             .exchange()
             .expectStatus().isOk()
-            .expectBody().jsonPath("$.value").isEqualTo("test");
+            .expectBody().jsonPath("$.value").isEqualTo("testing");
         Thread.sleep(100);
 
         assertEquals(0, openApiViolationLogger.getViolations().size());

--- a/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/OpenApiValidationIntegrationTest.java
+++ b/spring-boot-starter/spring-boot-starter-webflux/src/test/java/com/getyourguide/openapi/validation/integration/OpenApiValidationIntegrationTest.java
@@ -134,8 +134,6 @@ public class OpenApiValidationIntegrationTest {
         assertEquals(0, openApiViolationLogger.getViolations().size());
     }
 
-    // TODO Add test that fails on request violation immediately (maybe needs separate test class & setup) should not log violation
-
     @Nullable
     private OpenApiViolation getViolationByRule(List<OpenApiViolation> violations, String rule) {
         return violations.stream()


### PR DESCRIPTION
When `should-fail-on-request-violation` is enabled it will fail with a 400. In this case it should not report a violation as the request was correctly rejected.