### PR TITLE
[bugfix] Handle invalid spec on a spec with multiple spec setup

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/DefaultViolationLogger.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/DefaultViolationLogger.java
@@ -25,7 +25,7 @@ public class DefaultViolationLogger implements ViolationLogger {
                 default -> { /* do nothing */ }
             }
         } catch (IOException e) {
-            log.error("Could not add to LoggingContext", e);
+            log.error("[OpenAPI Validation] Could not add to LoggingContext", e);
         }
     }
 

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
@@ -56,7 +56,9 @@ public class OpenApiInteractionValidatorFactory {
                 }
                 var validator = buildSingleSpecOpenApiInteractionValidatorWrapper(specOptional.get(),
                     configuration.getLevelResolverLevels(), configuration.getLevelResolverDefaultLevel());
-                return Pair.of(entry.pathPattern(), (OpenApiInteractionValidatorWrapper) validator);
+                return validator != null
+                    ? Pair.of(entry.pathPattern(), (OpenApiInteractionValidatorWrapper) validator)
+                    : null;
             })
             .filter(Objects::nonNull)
             .collect(Collectors.toList());

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
@@ -56,9 +56,7 @@ public class OpenApiInteractionValidatorFactory {
                 }
                 var validator = buildSingleSpecOpenApiInteractionValidatorWrapper(specOptional.get(),
                     configuration.getLevelResolverLevels(), configuration.getLevelResolverDefaultLevel());
-                return validator != null
-                    ? Pair.of(entry.pathPattern(), (OpenApiInteractionValidatorWrapper) validator)
-                    : null;
+                return Pair.of(entry.pathPattern(), (OpenApiInteractionValidatorWrapper) validator);
             })
             .filter(Objects::nonNull)
             .collect(Collectors.toList());
@@ -71,6 +69,7 @@ public class OpenApiInteractionValidatorFactory {
         return new MultipleSpecOpenApiInteractionValidatorWrapper(validators);
     }
 
+    @Nullable
     private SingleSpecOpenApiInteractionValidatorWrapper buildSingleSpecOpenApiInteractionValidatorWrapper(
         String spec,
         Map<String, LogLevel> levelResolverLevels,

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiInteractionValidatorFactory.java
@@ -51,7 +51,7 @@ public class OpenApiInteractionValidatorFactory {
                 var path = entry.specificationFilePath();
                 var specOptional = loadSpecFromPath(path).or(() -> loadSpecFromResources(path));
                 if (specOptional.isEmpty()) {
-                    log.error("OpenAPI spec file {} could not be found", path);
+                    log.error("[OpenAPI Validation] Spec file {} could not be found", path);
                     return null;
                 }
                 var validator = buildSingleSpecOpenApiInteractionValidatorWrapper(specOptional.get(),
@@ -86,7 +86,7 @@ public class OpenApiInteractionValidatorFactory {
                 .build();
             return new SingleSpecOpenApiInteractionValidatorWrapper(validator);
         } catch (Throwable e) {
-            log.error("Could not initialize OpenApiInteractionValidator [validation disabled]", e);
+            log.error("[OpenAPI Validation] Could not initialize OpenApiInteractionValidator [validation disabled]", e);
             return null;
         }
     }

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
@@ -94,7 +94,7 @@ public class OpenApiRequestValidator {
             var result = validator.validateRequest(simpleRequest);
             return mapper.map(result, request, response, Direction.REQUEST, requestBody);
         } catch (Exception e) {
-            log.error("Could not validate request", e);
+            log.error("[OpenAPI Validation] Could not validate request", e);
             return List.of();
         }
     }
@@ -138,7 +138,7 @@ public class OpenApiRequestValidator {
             );
             return mapper.map(result, request, response, Direction.RESPONSE, responseBody);
         } catch (Exception e) {
-            log.error("Could not validate response", e);
+            log.error("[OpenAPI Validation] Could not validate response", e);
             return List.of();
         }
     }

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
@@ -40,7 +40,7 @@ public class MultipleSpecOpenApiInteractionValidatorWrapper implements OpenApiIn
     private Optional<OpenApiInteractionValidatorWrapper> getValidatorForPath(String path) {
         for (var validator : validators) {
             if (validator.getLeft().matcher(path).matches()) {
-                return Optional.of(validator.getRight());
+                return validator.getRight() == null ? Optional.of(validator.getRight()) : Optional.empty();
             }
         }
 

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapper.java
@@ -40,7 +40,7 @@ public class MultipleSpecOpenApiInteractionValidatorWrapper implements OpenApiIn
     private Optional<OpenApiInteractionValidatorWrapper> getValidatorForPath(String path) {
         for (var validator : validators) {
             if (validator.getLeft().matcher(path).matches()) {
-                return validator.getRight() == null ? Optional.of(validator.getRight()) : Optional.empty();
+                return validator.getRight() != null ? Optional.of(validator.getRight()) : Optional.empty();
             }
         }
 

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/validator/MultipleSpecOpenApiInteractionValidatorWrapperTest.java
@@ -56,6 +56,27 @@ public class MultipleSpecOpenApiInteractionValidatorWrapperTest {
         assertEquals("ValidatorConfiguration has no spec file matching path: /123", message.getMessage());
     }
 
+    @Test
+    public void testReturnsViolationWhenMatchingValidatorIsNull() {
+        var catchAllValidator = mockValidator();
+
+        validator = new MultipleSpecOpenApiInteractionValidatorWrapper(
+            List.of(
+                Pair.of(Pattern.compile("/test/.*"), null),
+                Pair.of(Pattern.compile(".*"), catchAllValidator.validator())
+            )
+        );
+
+        var path = "/test/123";
+        var report = validator.validateRequest(new SimpleRequest.Builder("GET", path).build());
+
+        var messages = report.getMessages();
+        assertEquals(1, messages.size());
+        var message = messages.get(0);
+        assertEquals(MESSAGE_KEY_NO_VALIDATOR_FOUND, message.getKey());
+        assertEquals("ValidatorConfiguration has no spec file matching path: /test/123", message.getMessage());
+    }
+
     private static MockValidatorResult mockValidator() {
         var catchAllValidator = mock(OpenApiInteractionValidatorWrapper.class);
         var catchAllValidationReport = mock(ValidationReport.class);


### PR DESCRIPTION
**Steps to reproduce**
- Setup with multiple specs
- Have one (or more) spec be invalid
- Startup

**Expected behaviour**
- It should log the failure
- It should ignore that spec (&path) but otherwise work the same still

**Actual behaviour**
- It logs the failure
- It throws an NPE whenever an endpoint with the invalid spec is validated