### PR TITLE
bugfix: undertow has missing request body

### DIFF
--- a/examples/http/requests.http
+++ b/examples/http/requests.http
@@ -1,0 +1,16 @@
+### POST request
+POST http://localhost:8080/
+Content-Type: application/json
+
+{
+  "name": 1
+}
+
+### GET request
+GET http://localhost:8080/?fromDate=2020-01-01
+
+### GET request (with body)
+GET http://localhost:8080/?fromDate=2020-01-01
+Content-Type: application/json
+
+{}

--- a/examples/openapi.yaml
+++ b/examples/openapi.yaml
@@ -35,7 +35,7 @@ paths:
       description: Update index
       operationId: postIndex
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/MultiReadContentCachingRequestWrapper.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/MultiReadContentCachingRequestWrapper.java
@@ -22,7 +22,7 @@ public class MultiReadContentCachingRequestWrapper extends ContentCachingRequest
     @Override
     public ServletInputStream getInputStream() throws IOException {
         var cachedContent = getContentAsByteArray();
-        if (cachedContent.length > 0 ) {
+        if (cachedContent.length > 0) {
             return new CachedServletInputStream(cachedContent);
         }
 

--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/MultiReadContentCachingRequestWrapper.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/MultiReadContentCachingRequestWrapper.java
@@ -21,12 +21,12 @@ public class MultiReadContentCachingRequestWrapper extends ContentCachingRequest
 
     @Override
     public ServletInputStream getInputStream() throws IOException {
-        var inputStream = super.getInputStream();
-        if (inputStream.isFinished()) {
-            return new CachedServletInputStream(getContentAsByteArray());
+        var cachedContent = getContentAsByteArray();
+        if (cachedContent.length > 0 ) {
+            return new CachedServletInputStream(cachedContent);
         }
 
-        return inputStream;
+        return super.getInputStream();
     }
 
     @Override


### PR DESCRIPTION
### Problem
When using `spring-boot-starter-undertow` all POST requests that require a body fail with a violation that body is required but missing.

### Solution
Somehow in undertow the InputStream is not finished but the cached content is already there. So we should read the cached content if there is any.