### PR TITLE
update: ignore unexpected body on GET/DELETE/OPTIONS/HEAD/TRACE

### DIFF
--- a/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/main/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptor.java
@@ -155,6 +155,12 @@ public class OpenApiValidationInterceptor implements AsyncHandlerInterceptor {
     }
 
     private static String readBodyCatchingException(MultiReadContentCachingRequestWrapper request) {
+        if (!"POST".equalsIgnoreCase(request.getMethod())
+            && !"PUT".equalsIgnoreCase(request.getMethod())
+            && !"PATCH".equalsIgnoreCase(request.getMethod())) {
+            return null;
+        }
+
         try {
             return StreamUtils.copyToString(request.getInputStream(), StandardCharsets.UTF_8);
         } catch (IOException e) {

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/BaseFilterTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/BaseFilterTest.java
@@ -53,6 +53,7 @@ public class BaseFilterTest {
 
     protected MockSetupData mockSetup(MockConfiguration configuration) {
         var request = mock(MultiReadContentCachingRequestWrapper.class);
+        when(request.getMethod()).thenReturn(configuration.requestMethod);
         var response = mock(ContentCachingResponseWrapper.class);
         var cachingRequest = mockContentCachingRequest(request, configuration);
         var cachingResponse = mockContentCachingResponse(response, configuration);
@@ -108,6 +109,7 @@ public class BaseFilterTest {
         MockConfiguration configuration
     ) {
         var cachingRequest = mock(MultiReadContentCachingRequestWrapper.class);
+        when(cachingRequest.getMethod()).thenReturn(configuration.requestMethod);
         when(contentCachingWrapperFactory.buildContentCachingRequestWrapper(request)).thenReturn(cachingRequest);
         if (configuration.requestBody != null) {
             try {
@@ -159,6 +161,8 @@ public class BaseFilterTest {
 
         @Builder.Default
         private String requestBody = REQUEST_BODY;
+        @Builder.Default
+        private String requestMethod = "POST";
         @Builder.Default
         private String responseBody = RESPONSE_BODY;
     }

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptorTest.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/filter/OpenApiValidationInterceptorTest.java
@@ -105,6 +105,18 @@ class OpenApiValidationInterceptorTest extends BaseFilterTest {
     }
 
     @Test
+    public void testShouldIgnoreBodyOnGetRequests() {
+        var mockData = mockSetup(MockConfiguration.builder().requestBody("{\"field\": 1}}").requestMethod("GET").build());
+
+        httpInterceptor.preHandle(mockData.request(), mockData.response(), new Object());
+        httpInterceptor.postHandle(mockData.request(), mockData.response(), new Object(), null);
+        httpInterceptor.afterCompletion(mockData.request(), mockData.response(), new Object(), null);
+
+        verifyRequestValidatedAsync(mockData, null);
+        verifyResponseValidatedAsync(mockData);
+    }
+
+    @Test
     public void testShouldFailOnResponseViolationWithViolation() {
         var mockData = mockSetup(MockConfiguration.builder().shouldFailOnResponseViolation(true).build());
         when(
@@ -140,10 +152,14 @@ class OpenApiValidationInterceptorTest extends BaseFilterTest {
     }
 
     private void verifyRequestValidatedAsync(MockSetupData mockData) {
+        verifyRequestValidatedAsync(mockData, REQUEST_BODY);
+    }
+
+    private void verifyRequestValidatedAsync(MockSetupData mockData, String requestBody) {
         verify(validator).validateRequestObjectAsync(
             eq(mockData.requestMetaData()),
             eq(mockData.responseMetaData()),
-            eq(REQUEST_BODY),
+            eq(requestBody),
             eq(openApiViolationHandler)
         );
     }


### PR DESCRIPTION
There are some clients that send a body on GET requests. This change ignores the request bodies on methods that don't support a request body.