### PR TITLE
feature: Provide custom MetricTags during runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ This can be achieved as demonstrated in the following snippet.
 public class MetricTagProviderExample implements MetricTagProvider {
   @Override
   public List<MetricTag> getTagsForViolation(OpenApiViolation violation) {
-    return List.of();
+    return List.of(new MetricTag("rule", violation.getRule()));
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ public class ViolationExclusionsExample implements ViolationExclusions {
 }
 ```
 
+### Provide metric tags at runtime
+Sometimes you want to generate your own metric tags based on the violation.
+This can be achieved as demonstrated in the following snippet.
+
+```java
+@Component
+public class MetricTagProviderExample implements MetricTagProvider {
+  @Override
+  public List<MetricTag> getTagsForViolation(OpenApiViolation violation) {
+    return List.of();
+  }
+}
+```
+
 ## Examples
 Run examples with `./gradlew :examples:example-spring-boot-starter-web:bootRun` or `./gradlew :examples:example-spring-boot-starter-webflux:bootRun`.
 

--- a/examples/example-spring-boot-starter-web/build.gradle
+++ b/examples/example-spring-boot-starter-web/build.gradle
@@ -9,7 +9,14 @@ plugins {
 dependencies {
     implementation project(':examples:examples-common')
     implementation project(':spring-boot-starter:spring-boot-starter-web')
-    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation('org.springframework.boot:spring-boot-starter-web') {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
+        exclude group: 'io.undertow', module: 'undertow-websockets-jsr'
+    }
+
+    implementation 'org.springframework.boot:spring-boot-starter-undertow'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.hibernate.validator:hibernate-validator'
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation(libs.openapi.tools.jacksonDatabindNullable)

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricTagProvider.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/MetricTagProvider.java
@@ -1,0 +1,8 @@
+package com.getyourguide.openapi.validation.api.metrics;
+
+import com.getyourguide.openapi.validation.api.model.OpenApiViolation;
+import java.util.List;
+
+public interface MetricTagProvider {
+    List<MetricTag> getTagsForViolation(OpenApiViolation violation);
+}

--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/NullMetricTagProvider.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/metrics/NullMetricTagProvider.java
@@ -1,0 +1,11 @@
+package com.getyourguide.openapi.validation.api.metrics;
+
+import com.getyourguide.openapi.validation.api.model.OpenApiViolation;
+import java.util.List;
+
+public class NullMetricTagProvider implements MetricTagProvider {
+    @Override
+    public List<MetricTag> getTagsForViolation(OpenApiViolation violation) {
+        return List.of();
+    }
+}


### PR DESCRIPTION
Until now one could only provide additional metric tags through the configuration file `application.properties`. Sometimes they should be provided at runtime.

This change allows providing MetricTags at runtime for each violation.

An example of such a provider (taken from the README.md):

```java
@Component
public class MetricTagProviderExample implements MetricTagProvider {
  @Override
  public List<MetricTag> getTagsForViolation(OpenApiViolation violation) {
    return List.of(new MetricTag("rule", violation.getRule()));
  }
}
```