### PR TITLE
fix: Do not report java.util.ConcurrentModificationException

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -17,7 +17,8 @@ public class InternalViolationExclusions {
             || falsePositive406(violation)
             || falsePositiveRequestWith4xxResponse(violation)
             || customViolationExclusions.isExcluded(violation)
-            || oneOfMatchesMoreThanOneSchema(violation);
+            || oneOfMatchesMoreThanOneSchema(violation)
+            || isConcurrentModificationExceptionInLibrary(violation);
     }
 
     private static boolean oneOfMatchesMoreThanOneSchema(OpenApiViolation violation) {
@@ -54,5 +55,10 @@ public class InternalViolationExclusions {
     private boolean falsePositive406(OpenApiViolation violation) {
         return violation.getResponseStatus().orElse(0) == 406
             && Rules.Response.STATUS_UNKNOWN.equals(violation.getRule());
+    }
+
+    private boolean isConcurrentModificationExceptionInLibrary(OpenApiViolation violation) {
+        return "validation.response.body.schema.unknownError".equals(violation.getRule())
+            && violation.getMessage().contains("java.util.ConcurrentModificationException");
     }
 }


### PR DESCRIPTION
The internally used library sometimes reports a violation like the following:
```
OpenAPI spec validation error [validation.response.body.schema.unknownError]
POST https://domain.com/v1/test
User Agent: ???
Response Status Code: 200

INFO - An error occurred during schema validation - com.google.common.util.concurrent.UncheckedExecutionException: java.util.ConcurrentModificationException.: []
```

As this is not a real violation, it should not be reported as such. Therefore adding it to be excluded.