### PR TITLE
feature: Exclude graphql paths by default

### DIFF
--- a/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelector.java
+++ b/openapi-validation-api/src/main/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelector.java
@@ -12,6 +12,7 @@ public class DefaultTrafficSelector implements TrafficSelector {
 
     private final double sampleRate;
     private final Set<String> excludedPaths;
+    private final Set<String> defaultExcludedPaths;
     private final List<ExcludedHeader> excludedHeaders;
     private final Boolean shouldFailOnRequestViolation;
     private final Boolean shouldFailOnResponseViolation;
@@ -28,6 +29,7 @@ public class DefaultTrafficSelector implements TrafficSelector {
         Boolean shouldFailOnResponseViolation
     ) {
         this.sampleRate = sampleRate;
+        this.defaultExcludedPaths = Set.of("/graphql", "/graphiql");
         this.excludedPaths = excludedPaths != null ? excludedPaths : Set.of();
         this.excludedHeaders = excludedHeaders != null ? excludedHeaders : Collections.emptyList();
         this.shouldFailOnRequestViolation = shouldFailOnRequestViolation != null ? shouldFailOnRequestViolation : false;
@@ -82,7 +84,8 @@ public class DefaultTrafficSelector implements TrafficSelector {
     }
 
     private boolean isRequestExcludedByPath(RequestMetaData request) {
-        return excludedPaths.contains(request.getUri().getPath());
+        var path = request.getUri().getPath();
+        return defaultExcludedPaths.contains(path) || excludedPaths.contains(path);
     }
 
     private static boolean methodEquals(String method, String expectedMethod) {

--- a/openapi-validation-api/src/test/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelectorTest.java
+++ b/openapi-validation-api/src/test/java/com/getyourguide/openapi/validation/api/selector/DefaultTrafficSelectorTest.java
@@ -31,11 +31,18 @@ class DefaultTrafficSelectorTest {
 
         assertHeaderIsExcluded(true, "x-is-bot", "true");
         assertHeaderIsExcluded(false, "x-is-bot", "truebot");
+    }
 
+    @Test
+    public void testIsExcludedByPath() {
+        // Default exclusions
+        assertPathIsExcluded(true, "/graphql");
+        assertPathIsExcluded(true, "/graphiql");
+
+        assertPathIsExcluded(false, "/v1/path");
     }
 
     private void assertHeaderIsExcluded(boolean expectedExclusion, String headerName, String headerValue) {
-
         var request = new RequestMetaData(
             "GET",
             URI.create("https://api.example.com/v1/path"),
@@ -44,6 +51,15 @@ class DefaultTrafficSelectorTest {
                 "Content-Length", "10",
                 headerName, headerValue
             ))
+        );
+        assertEquals(!expectedExclusion, trafficSelector.shouldRequestBeValidated(request));
+    }
+
+    private void assertPathIsExcluded(boolean expectedExclusion, String path) {
+        var request = new RequestMetaData(
+            "GET",
+            URI.create("https://api.example.com" + path),
+            Map.of("Content-Type", "application/json")
         );
         assertEquals(!expectedExclusion, trafficSelector.shouldRequestBeValidated(request));
     }


### PR DESCRIPTION
GraphQL has separate schemas that are used. The validator should not force those endpoints to have specified spec for these.