### PR TITLE
fix: Ignore unknownError related to ConcurrentModificationException

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -58,7 +58,7 @@ public class InternalViolationExclusions {
     }
 
     private boolean isConcurrentModificationExceptionInLibrary(OpenApiViolation violation) {
-        return "validation.response.body.schema.unknownError".equals(violation.getRule())
+        return violation.getRule() != null && violation.getRule().endsWith(".body.schema.unknownError")
             && violation.getMessage().contains("java.util.ConcurrentModificationException");
     }
 }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
@@ -159,6 +159,26 @@ public class InternalViolationExclusionsTest {
             .build());
     }
 
+    @Test
+    public void whenUnknownErrorWithConcurrentModificationExceptionThenViolationExcluded() {
+        when(customViolationExclusions.isExcluded(any())).thenReturn(false);
+        String message =
+            "An error occurred during schema validation - com.google.common.util.concurrent.UncheckedExecutionException: java.util.ConcurrentModificationException.";
+
+        checkViolationExcluded(OpenApiViolation.builder()
+            .direction(Direction.RESPONSE)
+            .rule("validation.request.body.schema.unknownError")
+            .responseStatus(200)
+            .message(message)
+            .build());
+        checkViolationExcluded(OpenApiViolation.builder()
+            .direction(Direction.RESPONSE)
+            .rule("validation.response.body.schema.unknownError")
+            .responseStatus(200)
+            .message(message)
+            .build());
+    }
+
     private void checkViolationNotExcluded(OpenApiViolation violation) {
         var isExcluded = violationExclusions.isExcluded(violation);
 


### PR DESCRIPTION
This seems to be a problem stemming from somewhere inside the swagger validation library used.