### PR TITLE
[CHK-11671] Remove undertow in example (security)

### DIFF
--- a/examples/example-spring-boot-starter-web/build.gradle
+++ b/examples/example-spring-boot-starter-web/build.gradle
@@ -9,16 +9,10 @@ plugins {
 dependencies {
     implementation project(':examples:examples-common')
     implementation project(':spring-boot-starter:spring-boot-starter-web')
-    implementation('org.springframework.boot:spring-boot-starter-web') {
-        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-tomcat'
-        exclude group: 'io.undertow', module: 'undertow-websockets-jsr'
-    }
-
-    implementation 'org.springframework.boot:spring-boot-starter-undertow'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.hibernate.validator:hibernate-validator'
+    implementation('org.springframework.boot:spring-boot-starter-web')
 
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
     implementation(libs.openapi.tools.jacksonDatabindNullable)
     implementation(libs.jakarta.validation.api)
     implementation(libs.swagger.annotations)


### PR DESCRIPTION
Undertow currently has a security advisory: https://access.redhat.com/security/cve/cve-2024-4109

Therefore removing undertow in the example for now.