### PR TITLE
[CHK-11672][CHK-11673] Update logback (security)

### DIFF
--- a/examples/example-spring-boot-starter-web/build.gradle
+++ b/examples/example-spring-boot-starter-web/build.gradle
@@ -5,6 +5,16 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
+// Needed for security. See:
+// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/7
+// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/6
+// Hopefully with spring-boot 3.4.2+ this won't be needed anymore and can be removed.
+dependencyManagement {
+    dependencies {
+        dependency 'ch.qos.logback:logback-core:1.5.15'
+        dependency 'ch.qos.logback:logback-classic:1.5.15'
+    }
+}
 
 dependencies {
     implementation project(':examples:examples-common')

--- a/examples/example-spring-boot-starter-webflux/build.gradle
+++ b/examples/example-spring-boot-starter-webflux/build.gradle
@@ -5,6 +5,17 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
+// Needed for security. See:
+// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/7
+// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/6
+// Hopefully with spring-boot 3.4.2+ this won't be needed anymore and can be removed.
+dependencyManagement {
+    dependencies {
+        dependency 'ch.qos.logback:logback-core:1.5.15'
+        dependency 'ch.qos.logback:logback-classic:1.5.15'
+    }
+}
+
 dependencies {
     implementation project(':examples:examples-common')
     implementation project(':spring-boot-starter:spring-boot-starter-webflux')


### PR DESCRIPTION
See:
- https://github.com/getyourguide/openapi-validation-java/security/dependabot/7
- https://github.com/getyourguide/openapi-validation-java/security/dependabot/6

Even newest spring boot 3.4.1 doesn't have the logback updated yet. Therefore doing it this way.