### PR TITLE
[CHK-11672][CHK-11673] Force min logback version correctly (security)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,4 +78,23 @@ subprojects {
         consoleOutput = true
         ruleSets = ["$rootDir/ruleset.xml"]
     }
+
+    // Needed for security. See:
+    // - https://github.com/getyourguide/openapi-validation-java/security/dependabot/7
+    // - https://github.com/getyourguide/openapi-validation-java/security/dependabot/6
+    // Hopefully with spring-boot 3.4.2+ this won't be needed anymore and can be removed.
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {details ->
+            if (details.requested.group == 'ch.qos.logback'
+                && (details.requested.name == 'logback-core' || details.requested.name == 'logback-classic')
+            ) {
+                def parse = { String v -> v.tokenize('.').collect { it.padLeft(3, '0') }.join() }
+                def current = parse(details.requested.version)
+                def minimum = parse('1.5.15')
+                if (current < minimum) {
+                    details.useVersion '1.5.15'
+                }
+            }
+        }
+    }
 }

--- a/examples/example-spring-boot-starter-web/build.gradle
+++ b/examples/example-spring-boot-starter-web/build.gradle
@@ -5,17 +5,6 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
-// Needed for security. See:
-// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/7
-// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/6
-// Hopefully with spring-boot 3.4.2+ this won't be needed anymore and can be removed.
-dependencyManagement {
-    dependencies {
-        dependency 'ch.qos.logback:logback-core:1.5.15'
-        dependency 'ch.qos.logback:logback-classic:1.5.15'
-    }
-}
-
 dependencies {
     implementation project(':examples:examples-common')
     implementation project(':spring-boot-starter:spring-boot-starter-web')

--- a/examples/example-spring-boot-starter-webflux/build.gradle
+++ b/examples/example-spring-boot-starter-webflux/build.gradle
@@ -5,17 +5,6 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
-// Needed for security. See:
-// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/7
-// - https://github.com/getyourguide/openapi-validation-java/security/dependabot/6
-// Hopefully with spring-boot 3.4.2+ this won't be needed anymore and can be removed.
-dependencyManagement {
-    dependencies {
-        dependency 'ch.qos.logback:logback-core:1.5.15'
-        dependency 'ch.qos.logback:logback-classic:1.5.15'
-    }
-}
-
 dependencies {
     implementation project(':examples:examples-common')
     implementation project(':spring-boot-starter:spring-boot-starter-webflux')


### PR DESCRIPTION
See:
- https://github.com/getyourguide/openapi-validation-java/security/dependabot/7
- https://github.com/getyourguide/openapi-validation-java/security/dependabot/6

Even newest spring boot 3.4.1 doesn't have the logback updated yet. Therefore doing it this way.

----

This is the second try to do this. Last time I only added it to the examples, but it was also a dependency in other places. With this it should correctly enforce it everywhere.