### PR TITLE
DEN-4986 [Automatic PR] Add concurrency to workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,10 @@ on:
       - '**'
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 jobs:
   check:
     uses: ./.github/workflows/check.yml

--- a/.github/workflows/repository-maintenance.yml
+++ b/.github/workflows/repository-maintenance.yml
@@ -2,8 +2,12 @@ name: Repository Maintenance
 
 on:
   push:
-    branches: [ 'main' ]
+    branches: ['main']
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}${{ github.ref_name != github.event.repository.default_branch && github.ref || github.run_id }}
+  cancel-in-progress: ${{ github.ref_name != github.event.repository.default_branch }}
 
 jobs:
   dependency-submission:


### PR DESCRIPTION
This is an automatic PR that adds concurrency to GHA workflows. As an effect there will be at most one running job __in a concurrency group__ (a branch) at any time, default branch excluded.
Optimizations like these are good for making runners available for other jobs, and will be enforced soon.

If you don't agree with these changes leave a review and raise your concern, otherwise please __merge the PR__.
