### PR TITLE
Support virtual threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ openapi.validation.validation-report-metric-additional-tags=service=example,team
 # Fail requests on request/response violations. Defaults to false.
 openapi.validation.should-fail-on-request-violation=true
 openapi.validation.should-fail-on-response-violation=true
+
+# Enable virtual threads for async validation. Defaults to false.
+openapi.validation.enable-virtual-threads=true
 ```
 
 ### DataDog metrics

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidator.java
@@ -14,26 +14,26 @@ import com.getyourguide.openapi.validation.core.validator.OpenApiInteractionVali
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.client.utils.URLEncodedUtils;
 
 @Slf4j
 public class OpenApiRequestValidator {
-    private final ThreadPoolExecutor threadPoolExecutor;
+    private final Executor executor;
     private final OpenApiInteractionValidatorWrapper validator;
     private final ValidationReportToOpenApiViolationsMapper mapper;
 
     public OpenApiRequestValidator(
-        ThreadPoolExecutor threadPoolExecutor,
+        Executor executor,
         MetricsReporter metricsReporter,
         OpenApiInteractionValidatorWrapper validator,
         ValidationReportToOpenApiViolationsMapper mapper,
         OpenApiRequestValidationConfiguration configuration
     ) {
-        this.threadPoolExecutor = threadPoolExecutor;
+        this.executor = executor;
         this.validator = validator;
         this.mapper = mapper;
 
@@ -74,7 +74,7 @@ public class OpenApiRequestValidator {
 
     private void executeAsync(Runnable command) {
         try {
-            threadPoolExecutor.execute(command);
+            executor.execute(command);
         } catch (RejectedExecutionException ignored) {
             // ignored
         }

--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/executor/VirtualThreadLimitedExecutor.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/executor/VirtualThreadLimitedExecutor.java
@@ -1,0 +1,54 @@
+package com.getyourguide.openapi.validation.core.executor;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class VirtualThreadLimitedExecutor implements Executor {
+    private static final int DEFAULT_MAX_CONCURRENT = 2;
+    private final int maxConcurrent;
+    private final AtomicInteger runningCount = new AtomicInteger(0);
+
+    public VirtualThreadLimitedExecutor() {
+        this(DEFAULT_MAX_CONCURRENT);
+    }
+
+    public VirtualThreadLimitedExecutor(int maxConcurrent) {
+        checkVirtualThreadSupport();
+        this.maxConcurrent = maxConcurrent;
+    }
+
+    public static boolean isSupported() {
+        try {
+            checkVirtualThreadSupport();
+            return true;
+        } catch (UnsupportedOperationException | NoSuchMethodError e) {
+            return false;
+        }
+    }
+
+    private static void checkVirtualThreadSupport() {
+        // This will throw NoSuchMethodError on Java < 21
+        //noinspection ResultOfMethodCallIgnored
+        Thread.ofVirtual();
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        if (runningCount.get() >= maxConcurrent) {
+            return;
+        }
+
+        if (runningCount.incrementAndGet() > maxConcurrent) {
+            runningCount.decrementAndGet();
+            return;
+        }
+
+        Thread.ofVirtual().start(() -> {
+            try {
+                command.run();
+            } finally {
+                runningCount.decrementAndGet();
+            }
+        });
+    }
+}

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/OpenApiRequestValidatorTest.java
@@ -14,8 +14,8 @@ import com.getyourguide.openapi.validation.core.validator.OpenApiInteractionVali
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.ThreadPoolExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -23,21 +23,21 @@ import org.mockito.Mockito;
 
 public class OpenApiRequestValidatorTest {
 
-    private ThreadPoolExecutor threadPoolExecutor;
+    private Executor executor;
     private OpenApiInteractionValidatorWrapper validator;
 
     private OpenApiRequestValidator openApiRequestValidator;
 
     @BeforeEach
     public void setup() {
-        threadPoolExecutor = mock();
+        executor = mock();
         validator = mock();
         MetricsReporter metricsReporter = mock();
         var mapper = mock(ValidationReportToOpenApiViolationsMapper.class);
         when(mapper.map(any(), any(), any(), any(), any())).thenReturn(List.of());
 
         openApiRequestValidator = new OpenApiRequestValidator(
-            threadPoolExecutor,
+            executor,
             metricsReporter,
             validator,
             mapper,
@@ -47,7 +47,7 @@ public class OpenApiRequestValidatorTest {
 
     @Test
     public void testWhenThreadPoolExecutorRejectsExecutionThenItShouldNotThrow() {
-        Mockito.doThrow(new RejectedExecutionException()).when(threadPoolExecutor).execute(any());
+        Mockito.doThrow(new RejectedExecutionException()).when(executor).execute(any());
 
         openApiRequestValidator.validateRequestObjectAsync(mock(), null, null, mock());
     }

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationProperties.java
@@ -38,6 +38,7 @@ public class OpenApiValidationApplicationProperties {
     private List<String> excludedHeaders;
     private Boolean shouldFailOnRequestViolation;
     private Boolean shouldFailOnResponseViolation;
+    private Boolean enableVirtualThreads;
 
     public double getSampleRate() {
         return sampleRate != null ? sampleRate : SAMPLE_RATE_DEFAULT;
@@ -82,6 +83,10 @@ public class OpenApiValidationApplicationProperties {
             })
             .filter(Objects::nonNull)
             .toList();
+    }
+
+    public boolean isEnableVirtualThreads() {
+        return enableVirtualThreads != null ? enableVirtualThreads : false;
     }
 
     public OpenApiRequestValidationConfiguration toOpenApiRequestValidationConfiguration() {

--- a/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/java/com/getyourguide/openapi/validation/autoconfigure/LibraryAutoConfiguration.java
@@ -119,11 +119,11 @@ public class LibraryAutoConfiguration {
     }
 
     private Executor createThreadPoolExecutor() {
-        if (VirtualThreadLimitedExecutor.isSupported()) {
+        if (properties.isEnableVirtualThreads() && VirtualThreadLimitedExecutor.isSupported()) {
             return new VirtualThreadLimitedExecutor();
         }
 
-        // Fallback to ThreadPoolExecutor with regular threads for older Java versions
+        // Fallback to ThreadPoolExecutor with regular threads
         return new ThreadPoolExecutor(
             2,
             2,

--- a/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationPropertiesTest.java
+++ b/spring-boot-starter/spring-boot-starter-core/src/test/java/com/getyourguide/openapi/validation/OpenApiValidationApplicationPropertiesTest.java
@@ -34,7 +34,8 @@ class OpenApiValidationApplicationPropertiesTest {
             EXCLUDED_PATHS,
             EXCLUDED_HEADERS,
             true,
-            false
+            false,
+            true
         );
 
         assertEquals(SAMPLE_RATE, loggingConfiguration.getSampleRate());

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/controller/DefaultRestController.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/controller/DefaultRestController.java
@@ -4,6 +4,7 @@ import com.getyourguide.openapi.validation.test.exception.WithResponseStatusExce
 import com.getyourguide.openapi.validation.test.exception.WithoutResponseStatusException;
 import com.getyourguide.openapi.validation.test.openapi.web.DefaultApi;
 import com.getyourguide.openapi.validation.test.openapi.web.model.PostTestRequest;
+import com.getyourguide.openapi.validation.test.openapi.web.model.TestEmailResponse;
 import com.getyourguide.openapi.validation.test.openapi.web.model.TestResponse;
 import java.time.LocalDate;
 import java.util.Objects;
@@ -24,6 +25,11 @@ public class DefaultRestController implements DefaultApi {
 
         var responseValue = value != null ? value : "test";
         return ResponseEntity.ok(new TestResponse().value(responseValue));
+    }
+
+    @Override
+    public ResponseEntity<TestEmailResponse> getTestEmail() {
+        return ResponseEntity.ok(new TestEmailResponse().email("mail@example.com"));
     }
 
     @Override

--- a/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/controller/DefaultRestController.java
+++ b/spring-boot-starter/spring-boot-starter-web/src/test/java/com/getyourguide/openapi/validation/integration/controller/DefaultRestController.java
@@ -4,7 +4,6 @@ import com.getyourguide.openapi.validation.test.exception.WithResponseStatusExce
 import com.getyourguide.openapi.validation.test.exception.WithoutResponseStatusException;
 import com.getyourguide.openapi.validation.test.openapi.web.DefaultApi;
 import com.getyourguide.openapi.validation.test.openapi.web.model.PostTestRequest;
-import com.getyourguide.openapi.validation.test.openapi.web.model.TestEmailResponse;
 import com.getyourguide.openapi.validation.test.openapi.web.model.TestResponse;
 import java.time.LocalDate;
 import java.util.Objects;
@@ -25,11 +24,6 @@ public class DefaultRestController implements DefaultApi {
 
         var responseValue = value != null ? value : "test";
         return ResponseEntity.ok(new TestResponse().value(responseValue));
-    }
-
-    @Override
-    public ResponseEntity<TestEmailResponse> getTestEmail() {
-        return ResponseEntity.ok(new TestEmailResponse().email("mail@example.com"));
     }
 
     @Override


### PR DESCRIPTION
# Description

Use virtual threads if available (Java 21+).
Same as with threads, limited to 2 virtual threads running in parallel.

Not enabled by default right now. Opt in to use virtual threads by adding the following to `application.properties`:
```
openapi.validation.enable-virtual-threads=true
```
