### PR TITLE
Fix ClassNotFoundException: javax.mail.internet.AddressException

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ mockito-junit-jupiter = { group = "org.mockito", name = "mockito-junit-jupiter",
 junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-platform" }
+javax-mail = { module = "com.sun.mail:javax.mail", version = "1.6.2" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/openapi-validation-core/build.gradle
+++ b/openapi-validation-core/build.gradle
@@ -4,6 +4,8 @@ dependencies {
     api project(':openapi-validation-api')
 
     implementation(libs.swagger.request.validator.core)
+    implementation(libs.javax.mail) // needed as otherwise ClassNotFoundException: javax.mail.internet.AddressException
+
     constraints {
         implementation(libs.commons.codec) {
             because 'Apache commons-codec before 1.13 is vulnerable to information exposure. See https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/'


### PR DESCRIPTION
# Description

Without this we often get the following error in the logs and validation is disabled (service start still worked fine).

> [OpenAPI Validation] Could not initialize OpenApiInteractionValidator [validation disabled]
> java.lang.ClassNotFoundException: javax.mail.internet.AddressException