### PR TITLE
Exclude library internal exception `unhandled token type NOT_AVAILABLE`

### DIFF
--- a/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
+++ b/openapi-validation-core/src/main/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusions.java
@@ -18,7 +18,8 @@ public class InternalViolationExclusions {
             || falsePositiveRequestWith4xxResponse(violation)
             || customViolationExclusions.isExcluded(violation)
             || oneOfMatchesMoreThanOneSchema(violation)
-            || isConcurrentModificationExceptionInLibrary(violation);
+            || isConcurrentModificationExceptionInLibrary(violation)
+            || isUnhandledUncheckedExecutionExceptionInLibrary(violation);
     }
 
     private static boolean oneOfMatchesMoreThanOneSchema(OpenApiViolation violation) {
@@ -60,5 +61,11 @@ public class InternalViolationExclusions {
     private boolean isConcurrentModificationExceptionInLibrary(OpenApiViolation violation) {
         return violation.getRule() != null && violation.getRule().endsWith(".body.schema.unknownError")
             && violation.getMessage().contains("java.util.ConcurrentModificationException");
+    }
+
+    private boolean isUnhandledUncheckedExecutionExceptionInLibrary(OpenApiViolation violation) {
+        return violation.getRule() != null && violation.getRule().endsWith(".body.schema.unknownError")
+            && violation.getMessage().contains("UncheckedExecutionException")
+            && violation.getMessage().contains("unhandled token type NOT_AVAILABLE");
     }
 }

--- a/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
+++ b/openapi-validation-core/src/test/java/com/getyourguide/openapi/validation/core/exclusions/InternalViolationExclusionsTest.java
@@ -179,6 +179,26 @@ public class InternalViolationExclusionsTest {
             .build());
     }
 
+    @Test
+    public void whenUnknownErrorWithNotAvailableTokenThenViolationExcluded() {
+        when(customViolationExclusions.isExcluded(any())).thenReturn(false);
+        String message =
+            "An error occurred during schema validation - com.google.common.util.concurrent.UncheckedExecutionException: java.lang.NullPointerException: unhandled token type NOT_AVAILABLE.";
+
+        checkViolationExcluded(OpenApiViolation.builder()
+            .direction(Direction.RESPONSE)
+            .rule("validation.request.body.schema.unknownError")
+            .responseStatus(200)
+            .message(message)
+            .build());
+        checkViolationExcluded(OpenApiViolation.builder()
+            .direction(Direction.RESPONSE)
+            .rule("validation.response.body.schema.unknownError")
+            .responseStatus(200)
+            .message(message)
+            .build());
+    }
+
     private void checkViolationNotExcluded(OpenApiViolation violation) {
         var isExcluded = violationExclusions.isExcluded(violation);
 


### PR DESCRIPTION
This excludes an internal exception from being reported:

```
INFO - An error occurred during schema validation - com.google.common.util.concurrent.UncheckedExecutionException: java.lang.NullPointerException: unhandled token type NOT_AVAILABLE.:
```