### PR TITLE
[CHK-12382] Fix transitive dep vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,9 @@ subprojects {
             implementation("org.apache.commons:commons-lang3:3.18.0") {
                 because("versions below 3.18.0 have security vulnerabilities including CVE-2025-48924 - see dependabot #15")
             }
+            implementation("io.projectreactor.netty:reactor-netty-http:1.2.8") {
+                because("versions below 1.2.8 have security vulnerabilities including CVE-2025-22227 - see dependabot #16")
+            }
         }
     }
 


### PR DESCRIPTION
https://getyourguide.atlassian.net/browse/CHK-12382

Fixes `dependabot` [alert](https://github.com/getyourguide/openapi-validation-java/security/dependabot/16). 

