### PR TITLE
[CHK-12456] Upgrade dependencies due to security alert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 ext['spring-framework.version'] = '6.2.10'
-ext['tomcat.version'] = '10.1.42'
+ext['tomcat.version'] = '11.0.10'
 
 apply from: "${rootDir}/gradle/publish-root.gradle"
 


### PR DESCRIPTION
Should fix this security alert: https://github.com/getyourguide/openapi-validation-java/security/dependabot/19

Jira: CHK-12456

## How was this tested

<!-- Mention anything specific -->

