### PR TITLE
Use github tag for release version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,17 @@
 # Release process
 
-1. Update the `version` in `build.gradle`
-   - Push this to `main` (optionally with a PR)
-2. Create a new release on github: [direct link](https://github.com/getyourguide/openapi-validation-java/releases/new)
-   - Choose a tag `v....` (the new version)
-   - Select "Create new tag"
-   - Press "Generate release notes"
-   - Publish release
+- Create a new release on github: [direct link](https://github.com/getyourguide/openapi-validation-java/releases/new)
+- Choose a tag `v....` (the new version)
+- Select "Create new tag"
+- Press "Generate release notes"
+- Publish release
+
+## Release SNAPSHOT version from branch
+
+- Create a new release on github: [direct link](https://github.com/getyourguide/openapi-validation-java/releases/new)
+- Choose a tag `v....` (the new version)
+- Select "Create new tag"
+- **Choose your branch as target**
+- Press "Generate release notes"
+- **Check "Set as a pre-release"**
+- Publish release

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,8 @@ apply from: "${rootDir}/gradle/publish-root.gradle"
 allprojects {
     group = 'com.getyourguide.openapi.validation'
     description = 'OpenAPI Validation library'
-    version = '3.3.2'
+    // Use version from GitHub tag if provided, otherwise use default version
+    version = project.hasProperty('gh_tag') ? project.property('gh_tag').replaceFirst('^v', '') : '0-SNAPSHOT'
 
     java {
         toolchain {


### PR DESCRIPTION
## Summary

This pull request updates the release process to utilize GitHub tags for setting the release version. The changes include:

- **RELEASE.md**: Updated to reflect the new process of creating releases directly from GitHub, including instructions for releasing SNAPSHOT versions from branches.
- **build.gradle**: Modified to set the project version based on a GitHub tag if available, defaulting to '0-SNAPSHOT' otherwise.

These changes aim to simplify and automate the release process, ensuring consistency in versioning.

---

<!-- Anything you add here will be preserved by the automation that sets the description -->

<!--
1. Always set a descriptive title, example: "DEN-1234: bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
4. Learn more about code reviews here: https://getyourguide.slack.com/archives/C08TS816V3L
-->