### PR TITLE
Use github tag for release version (fix)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,13 @@ jobs:
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
         with:
           arguments: sourcesJar javadocJar
+      - name: Get tag
+        shell: bash
+        id: get_tag
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "Github tag: $TAG"
+          echo "gh_tag=${TAG#v}" >> "$GITHUB_OUTPUT"
       - name: Publish to MavenCentral
         uses: gradle/gradle-build-action@a8f75513eafdebd8141bd1cd4e30fcd194af8dfa # v2.12.0
         with:
@@ -38,3 +45,4 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          GH_TAG: "${{ steps.get_tag.outputs.gh_tag }}"

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ allprojects {
     group = 'com.getyourguide.openapi.validation'
     description = 'OpenAPI Validation library'
     // Use version from GitHub tag if provided, otherwise use default version
-    version = project.hasProperty('gh_tag') ? project.property('gh_tag').replaceFirst('^v', '') : '0-SNAPSHOT'
+    version = System.getenv('GH_TAG') ? System.getenv('GH_TAG').replaceFirst('^v', '') : '0-SNAPSHOT'
 
     java {
         toolchain {


### PR DESCRIPTION
## Summary

This pull request updates the CI/CD pipeline to utilize the GitHub tag for determining the release version. The changes include:

- Modifying the `.github/workflows/publish.yml` to extract the tag from the GitHub reference and set it as an output variable.
- Updating `build.gradle` to use the environment variable `GH_TAG` for setting the project version.

These changes ensure that the release version aligns with the GitHub tag, improving the consistency of versioning in the release process.

---

<!-- Anything you add here will be preserved by the automation that sets the description -->

<!--
1. Always set a descriptive title, example: "DEN-1234: bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
4. Learn more about code reviews here: https://getyourguide.slack.com/archives/C08TS816V3L
-->