### PR TITLE
[CHK-12769][CHK-12772] fix dependabot security alert

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 ext['spring-framework.version'] = '6.2.11'
-ext['tomcat.version'] = '11.0.11'
+ext['tomcat.version'] = '11.0.12'
 ext['netty.version'] = '4.2.6.Final' // Due to security vulnerabilities in 4.125.Final and older
 
 apply from: "${rootDir}/gradle/publish-root.gradle"
@@ -78,7 +78,7 @@ subprojects {
                 because("versions below 6.2.11 have security vulnerabilities including CVE-2025-41242 and CVE-2025-41249 - see dependabot #24, #247")
             }
             implementation("org.apache.tomcat.embed:tomcat-embed-core:11.0.13") {
-                because("versions below 10.1.42 have security vulnerabilities including CVE-2024-56337 - see dependabot #13")
+                because("versions below 11.0.12 have security vulnerabilities including CVE-2024-56337, CVE-2025-55754, CVE-2025-61795 - see dependabot #13, #27, #28")
             }
             implementation("org.apache.commons:commons-lang3:3.19.0") {
                 because("versions below 3.18.0 have security vulnerabilities including CVE-2025-48924 - see dependabot #15")

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 ext['spring-framework.version'] = '6.2.11'
-ext['tomcat.version'] = '11.0.10'
+ext['tomcat.version'] = '11.0.11'
 ext['netty.version'] = '4.2.6.Final' // Due to security vulnerabilities in 4.125.Final and older
 
 apply from: "${rootDir}/gradle/publish-root.gradle"


### PR DESCRIPTION
## Summary
This PR addresses the security vulnerabilities reported by Dependabot for the Apache Tomcat embedded core library by upgrading the version from 11.0.10 to 11.0.12 in the build.gradle file.

## Details
- Updated `ext['tomcat.version']` from `11.0.10` to `11.0.12`.
- Adjusted the implementation version of `tomcat-embed-core` to `11.0.13` with updated security vulnerability notes.

## JIRA Ticket
This change resolves the security alert described in JIRA ticket **CHK-12769**, which highlights the need to update the vulnerable Apache Tomcat dependency to mitigate security risks.

---

<!-- Anything you add here will be preserved by the automation that sets the description -->

<!--
1. Always set a descriptive title, example: "DEN-1234: bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
4. Learn more about code reviews here: https://getyourguide.slack.com/archives/C08TS816V3L
-->