### PR TITLE
CHK-12903: Fix dependabot alert 29 (org.mozilla:rhino)

### DIFF
--- a/openapi-validation-core/build.gradle
+++ b/openapi-validation-core/build.gradle
@@ -10,6 +10,9 @@ dependencies {
         implementation(libs.commons.codec) {
             because 'Apache commons-codec before 1.13 is vulnerable to information exposure. See https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/'
         }
+        implementation('org.mozilla:rhino:1.7.14.1') {
+            because 'CVE-2025-66453: Rhino before 1.7.14.1 has high CPU usage and potential DoS when passing specific numbers to toFixed() function. See https://github.com/mozilla/rhino/security/advisories/GHSA-3w8q-xq97-5j7x'
+        }
 //        implementation('org.yaml:snakeyaml:1.33') {
 //            because 'Vulnerability in 1.33 is not yet fixed. See: https://bitbucket.org/snakeyaml/snakeyaml/issues/561/cve-2022-1471-vulnerability-in' +
 //                    'https://devhub.checkmarx.com/cve-details/CVE-2022-41854/' +


### PR DESCRIPTION
This PR addresses the security alert CHK-12903 by updating the vulnerable dependency 'org.mozilla:rhino' to version 1.7.14.1 in the build.gradle file. This update mitigates the CVE-2025-66453 vulnerability that could cause high CPU usage and potential denial of service when passing specific numbers to the toFixed() function in Rhino.

---

<!-- Anything you add here will be preserved by the automation that sets the description -->

<!--
1. Always set a descriptive title, example: "DEN-1234: bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
4. Learn more about code reviews here: https://getyourguide.slack.com/archives/C08TS816V3L
-->