### PR TITLE
CHK-13036: Fix dependabot alert 30 (io.netty:netty-codec-http)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,14 @@ subprojects {
         annotationProcessor(libs.lombok)
         testCompileOnly(libs.lombok)
         testAnnotationProcessor(libs.lombok)
+
+        // Security: override transitive netty-codec-http to fix CVE-2025-67735 (CRLF injection)
+        constraints {
+            implementation('io.netty:netty-codec-http') {
+                version { require libs.versions.netty.get() }
+                because 'CVE-2025-67735: CRLF injection in HttpRequestEncoder'
+            }
+        }
     }
 
     checkstyle {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lombok = "1.18.42"
 commons-codec = "1.20.0"
 find-bugs = "3.0.2"
 gradle-nexus-publish-plugin = "2.0.0"
+netty = "4.2.8.Final"
 datadog-statsd = "4.4.5"
 # Verify
 checkstyle = "8.44"


### PR DESCRIPTION
## Summary

- Fixes [Dependabot alert #30](https://github.com/getyourguide/openapi-validation-java/security/dependabot/30) — **CVE-2025-67735**: CRLF injection in `io.netty.handler.codec.http.HttpRequestEncoder`
- Upgrades transitive `io.netty:netty-codec-http` from `4.2.7.Final` to `4.2.8.Final` via a Gradle dependency constraint
- The vulnerable package is a transitive dependency from Spring Boot 4.0.0 → `reactor-netty-http` → `netty-codec-http`, so a constraint override is used rather than a direct dependency update

## Changes

- **`gradle/libs.versions.toml`** — Added `netty = "4.2.8.Final"` version entry
- **`build.gradle`** — Added dependency constraint in `subprojects` to force `io.netty:netty-codec-http` to the patched version