### PR TITLE
CHK-13035: Fix dependabot alert 31: upgrade logback to 1.5.25 (CVE-2026-1225)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,17 @@ subprojects {
         }
     }
 
+    // Override logback version to fix CVE-2026-1225 (transitive via Spring Boot)
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == 'ch.qos.logback') {
+                useVersion libs.versions.logback.get()
+            }
+        }
+    }
+
+    ext['logback.version'] = libs.versions.logback.get()
+
     apply plugin: 'checkstyle'
     apply plugin: 'pmd'
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 java = "21"
 spring-boot = "4.0.0"
+logback = "1.5.25" # Override Spring Boot managed version to fix CVE-2026-1225 (GHSA-qqpg-mvqg-649v)
 spring-dependency-management = "1.1.7"
 openapi-generator = "7.17.0"
 openapi-tools = "0.2.8"
@@ -29,6 +30,8 @@ jakarta-validation-api = { group = "jakarta.validation", name = "jakarta.validat
 lombok = { group = "org.projectlombok", name = "lombok", version.ref = "lombok" }
 datadog-statsdclient = { group = "com.datadoghq", name = "java-dogstatsd-client", version.ref = "datadog-statsd" }
 commons-codec = { group = "commons-codec", name = "commons-codec", version.ref = "commons-codec" }
+logback-classic = { group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
+logback-core = { group = "ch.qos.logback", name = "logback-core", version.ref = "logback" }
 find-bugs = { group = "com.google.code.findbugs", name = "jsr305", version.ref = "find-bugs" }
 # Testing
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
## Summary

- Upgrades `ch.qos.logback:logback-core` from 1.5.21 to 1.5.25 to fix [CVE-2026-1225](https://github.com/getyourguide/openapi-validation-java/security/dependabot/31) (ACE vulnerability in logback configuration file processing)
- Logback is a transitive dependency via Spring Boot 4.0.0's BOM — Spring Boot hasn't released a version with the fix yet
- Uses both `resolutionStrategy` (for subprojects using `platform(SpringBootPlugin.BOM_COORDINATES)`) and `ext['logback.version']` (for subprojects using `io.spring.dependency-management` plugin) to ensure all subprojects resolve to 1.5.25

## Changes

- `gradle/libs.versions.toml`: Added `logback = "1.5.25"` version and library entries
- `build.gradle`: Added resolution strategy and ext property override in `subprojects` block

## Verification

- All subprojects resolve `logback-core` to 1.5.25 (verified via `./gradlew dependencies`)
- Compilation and tests pass (`./gradlew compileJava compileTestJava test`)