### PR TITLE
Add configuration metadata for OpenAPI validation options

### DIFF
--- a/spring-boot-starter/spring-boot-starter-core/src/main/resources/META-INF/spring-configuration-metadata.json
+++ b/spring-boot-starter/spring-boot-starter-core/src/main/resources/META-INF/spring-configuration-metadata.json
@@ -49,6 +49,11 @@
       "name": "openapi.validation.should-fail-on-response-violation",
       "type": "java.lang.Boolean",
       "description": "If set to true the request will fail in case a response violation occurs. Defaults to false."
+    },
+    {
+      "name": "openapi.validation.enable-virtual-threads",
+      "type": "java.lang.Boolean",
+      "description": "If set to true will use virtual threads instead of normal threads for async processing. Defaults to false."
     }
   ]
 }


### PR DESCRIPTION
## Summary
This pull request enhances the Spring Boot starter's configuration metadata by adding a new option: `openapi.validation.enable-virtual-threads`. This option allows toggling virtual threads for asynchronous processing within the OpenAPI validation library. The addition is purely metadata for configuration and does not affect runtime behavior directly.

The file modified is:
- `spring-boot-starter-core/src/main/resources/META-INF/spring-configuration-metadata.json`

This change helps documentation and tooling to recognize the new configuration property.

No business logic was altered. The PR is currently marked as a draft.

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->