### PR TITLE
build(deps): bump spring-boot from 4.0.2 to 4.0.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 java = "21"
-spring-boot = "4.0.2"
+spring-boot = "4.0.4"
 spring-dependency-management = "1.1.7"
 openapi-generator = "7.20.0"
 openapi-tools = "0.2.9"


### PR DESCRIPTION
## Summary

- Upgrades Spring Boot from `4.0.2` to `4.0.4`
- Spring Boot 4.0.4 brings Spring Framework **7.0.6** (patched version)
- Fixes [CVE-2026-22737](https://github.com/advisories/GHSA-4773-3jfm-qmx3) — path traversal via script view templates in Spring MVC/WebFlux (CVSS 5.9 medium)

## Details

`org.springframework:spring-webflux` is a transitive dependency pulled in via the Spring Boot BOM. Spring Boot 4.0.2 resolves Spring Framework 7.0.3 (vulnerable), and 4.0.3 resolves 7.0.5 (still vulnerable). Spring Boot 4.0.4 is the first release that includes Spring Framework 7.0.6 (patched).

## Test plan

- [x] `./gradlew test` passes (56 tasks, BUILD SUCCESSFUL)
- [x] `spring-webflux` resolves to `7.0.6` after upgrade

Closes #40 (Dependabot alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)