### PR TITLE
CHK-13321: Upgrade jackson-bom to 3.1.1 for GHSA-2m67-wjpj-xhg9

### DIFF
--- a/examples/example-spring-boot-starter-web/build.gradle
+++ b/examples/example-spring-boot-starter-web/build.gradle
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
+ext['jackson-bom.version'] = '3.1.1'
+
 dependencies {
     implementation project(':examples:examples-common')
     implementation project(':spring-boot-starter:spring-boot-starter-web')

--- a/examples/example-spring-boot-starter-webflux/build.gradle
+++ b/examples/example-spring-boot-starter-webflux/build.gradle
@@ -5,6 +5,8 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
+ext['jackson-bom.version'] = '3.1.1'
+
 dependencies {
     implementation project(':examples:examples-common')
     implementation project(':spring-boot-starter:spring-boot-starter-webflux')


### PR DESCRIPTION
## Summary
- Fixes security vulnerability GHSA-2m67-wjpj-xhg9 in `tools.jackson.core:jackson-core` by overriding the Jackson BOM version to 3.1.1
- The existing `strictly` constraint in `openapi-validation-core` was being overridden by the Spring Boot dependency management plugin; this adds `ext['jackson-bom.version'] = '3.1.1'` to the affected example projects

## Vulnerability Details
- **GHSA**: GHSA-2m67-wjpj-xhg9
- **Severity**: HIGH (CVSS 7.5)
- **Vulnerable Range**: `>= 3.0.0, <= 3.1.0`
- **Patched Version**: `3.1.1`
- **Package**: `tools.jackson.core:jackson-core`

## Changes
- Added `ext['jackson-bom.version'] = '3.1.1'` to `examples/example-spring-boot-starter-web/build.gradle`
- Added `ext['jackson-bom.version'] = '3.1.1'` to `examples/example-spring-boot-starter-webflux/build.gradle`

## Testing
- ✅ Verified `tools.jackson.core:jackson-core` resolves to 3.1.1 in both example projects
- ✅ All tests passing locally

## References
- Jira: https://getyourguide.atlassian.net/browse/CHK-13321
- GitHub Alert: https://github.com/getyourguide/openapi-validation-java/security/dependabot/41
- Security Advisory: https://github.com/FasterXML/jackson-core/security/advisories/GHSA-2m67-wjpj-xhg9

🤖 Generated with [Claude Code](https://claude.com/claude-code)