### PR TITLE
CHK-13321: Force jackson-core 3.1.1 across all Gradle configurations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,15 @@ allprojects {
 }
 
 subprojects {
+    configurations.configureEach {
+        resolutionStrategy.eachDependency {
+            if (requested.group == 'tools.jackson.core' && requested.name == 'jackson-core') {
+                useVersion('3.1.1')
+                because('GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 maxDocumentLength bypass')
+            }
+        }
+    }
+
     if(it.parent.name == 'examples') {
         apply plugin: 'java'
     } else {

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ allprojects {
 subprojects {
     configurations.configureEach {
         resolutionStrategy.eachDependency {
-            if (requested.group == 'tools.jackson.core' && requested.name == 'jackson-core') {
+            if (requested.group == 'tools.jackson.core' && requested.name == 'jackson-core'
+                    && requested.version != null && requested.version < '3.1.1') {
                 useVersion('3.1.1')
                 because('GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 maxDocumentLength bypass')
             }


### PR DESCRIPTION
## Summary
- Adds a project-wide `resolutionStrategy` to force `tools.jackson.core:jackson-core` to 3.1.1 across ALL configurations in ALL subprojects
- The previous fix (`ext['jackson-bom.version']`) only covered example projects using the `spring-dependency-management` plugin
- The `spring-boot-starter-web` and `spring-boot-starter-webflux` modules use `compileOnly` with `platform(SpringBootPlugin.BOM_COORDINATES)`, so `jackson-core:3.1.0` remained on their `compileClasspath`
- Since the dependency submission action includes `compileClasspath`, the Dependabot alert stayed open

## Vulnerability Details
- **GHSA**: GHSA-2m67-wjpj-xhg9
- **Severity**: HIGH (CVSS 7.5)
- **Vulnerable Range**: `>= 3.0.0, <= 3.1.0`
- **Patched Version**: `3.1.1`
- **Package**: `tools.jackson.core:jackson-core`

## Changes
- Added `configurations.configureEach` with `resolutionStrategy.eachDependency` in root `build.gradle` `subprojects` block

## Testing
- ✅ Verified `jackson-core` resolves to 3.1.1 on `compileClasspath` for both `spring-boot-starter-web` and `spring-boot-starter-webflux`
- ✅ All tests passing locally

## References
- Jira: https://getyourguide.atlassian.net/browse/CHK-13321
- GitHub Alert: https://github.com/getyourguide/openapi-validation-java/security/dependabot/41
- Security Advisory: https://github.com/FasterXML/jackson-core/security/advisories/GHSA-2m67-wjpj-xhg9

🤖 Generated with [Claude Code](https://claude.com/claude-code)