### PR TITLE
[USPR-XXXX] fix dependabot 42,43,44

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,11 @@ subprojects {
                 useVersion('3.1.1')
                 because('GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 maxDocumentLength bypass')
             }
+            if (requested.group == 'org.apache.tomcat.embed' && requested.name == 'tomcat-embed-core'
+                    && requested.version != null && requested.version < '11.0.21') {
+                useVersion('11.0.21')
+                because('GHSA-rv64-5gf8-9qq8 / GHSA-x4m4-345f-5h5g / GHSA-24j9-x2wg-9qv6: Apache Tomcat < 11.0.21 vulnerabilities')
+            }
         }
     }
 


### PR DESCRIPTION
## Security Patch: Apache Tomcat Vulnerability Fix

### Changes
- Added Gradle dependency constraint to enforce Apache Tomcat Embed Core version 11.0.21+
- Addresses three security vulnerabilities: GHSA-rv64-5gf8-9qq8, GHSA-x4m4-345f-5h5g, GHSA-24j9-x2wg-9qv6
- Gradle wrapper script normalized to Unix line endings (no functional change)

### Impact
- Prevents transitive dependencies from using vulnerable Tomcat versions
- Aligns with Dependabot security recommendations