### PR TITLE
Fix versions for dependencies to address vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,25 +23,6 @@ allprojects {
 }
 
 subprojects {
-    configurations.configureEach {
-        resolutionStrategy.eachDependency {
-            if (requested.group == 'tools.jackson.core' && requested.name == 'jackson-core'
-                    && requested.version != null && requested.version < '3.1.1') {
-                useVersion('3.1.1')
-                because('GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 maxDocumentLength bypass')
-            }
-            if (requested.group == 'org.apache.tomcat.embed' && requested.name == 'tomcat-embed-core'
-                    && requested.version != null && requested.version < '11.0.22') {
-                useVersion('11.0.22')
-                because('GHSA-rv64-5gf8-9qq8 / GHSA-x4m4-345f-5h5g / GHSA-24j9-x2wg-9qv6 / GHSA-gx5v-xp9w-j4cg: Apache Tomcat < 11.0.22 vulnerabilities')
-            }
-            if (requested.group == 'io.netty' && requested.version != null && requested.version < '4.2.13.Final') {
-                useVersion('4.2.13.Final')
-                because('GHSA-38f8-5428-x5cv: HTTP Request Smuggling in io.netty:netty-codec-http via malformed Transfer-Encoding headers')
-            }
-        }
-    }
-
     if(it.parent.name == 'examples') {
         apply plugin: 'java'
     } else {
@@ -78,6 +59,28 @@ subprojects {
     apply plugin: 'pmd'
 
     dependencies {
+        constraints {
+            add('implementation', 'tools.jackson.core:jackson-core') {
+                version {
+                    require '[3.1.1,)'
+                }
+                because('GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 maxDocumentLength bypass')
+            }
+            add('implementation', 'org.apache.tomcat.embed:tomcat-embed-core') {
+                version {
+                    require '[11.0.22,)'
+                }
+                because('GHSA-rv64-5gf8-9qq8 / GHSA-x4m4-345f-5h5g / GHSA-24j9-x2wg-9qv6 / GHSA-gx5v-xp9w-j4cg: Apache Tomcat < 11.0.22 vulnerabilities')
+            }
+            add('implementation', 'io.netty:netty-codec-http') {
+                version {
+                    require '[4.2.13.Final,)'
+                    prefer '4.2.14.Final'
+                }
+                because('GHSA-38f8-5428-x5cv: HTTP Request Smuggling in io.netty:netty-codec-http via malformed Transfer-Encoding headers')
+            }
+        }
+
         // Lombok annotations to reduce boilerplate code
         compileOnly(libs.lombok)
         annotationProcessor(libs.lombok)


### PR DESCRIPTION
## Security Vulnerability Fixes

Addresses three known security vulnerabilities by enforcing minimum dependency versions:

- **Jackson Core**: Bump to 3.1.1+ to fix maxDocumentLength bypass (GHSA-2m67-wjpj-xhg9)
- **Apache Tomcat Embed**: Bump to 11.0.22+ to fix multiple vulnerabilities (GHSA-rv64-5gf8-9qq8 and 3 others)
- **Netty Codec HTTP**: Bump to 4.2.13.Final+ to fix HTTP Request Smuggling via malformed Transfer-Encoding headers (GHSA-38f8-5428-x5cv)

## Implementation Change

Refactors from global `resolutionStrategy.eachDependency` block to Gradle `constraints` DSL within dependencies block, improving dependency resolution clarity and maintainability.

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->