### PR TITLE
Force versions in the examples

### DIFF
--- a/examples/example-spring-boot-starter-web/build.gradle
+++ b/examples/example-spring-boot-starter-web/build.gradle
@@ -6,6 +6,8 @@ plugins {
 }
 
 ext['jackson-bom.version'] = '3.1.1'
+ext['netty.version'] = '4.2.13.Final'
+ext['tomcat.version'] = '11.0.22'
 
 dependencies {
     implementation project(':examples:examples-common')

--- a/examples/example-spring-boot-starter-webflux/build.gradle
+++ b/examples/example-spring-boot-starter-webflux/build.gradle
@@ -6,6 +6,8 @@ plugins {
 }
 
 ext['jackson-bom.version'] = '3.1.1'
+ext['netty.version'] = '4.2.13.Final'
+ext['tomcat.version'] = '11.0.22'
 
 dependencies {
     implementation project(':examples:examples-common')


### PR DESCRIPTION
## Summary
Force specific versions for Netty and Tomcat dependencies in the example Spring Boot applications.

## Changes
- Pin `netty.version` to `4.2.13.Final` in both web and webflux example build configurations
- Pin `tomcat.version` to `11.0.22` in both example modules
- Ensures consistent transitive dependency resolution across example projects

## Impact
- Stabilizes example builds and reduces version mismatch issues
- Affects only example modules, not core library code
- No functional changes to production code

---

<!-- Automated description preserves everything you've added after the comment above -->

<!--
1. Always set a descriptive title, example: "bugfix: handle nil value in payment". 
2. Aim to open the PR as draft to prevent CODEOWNERS from being notified before the PR is ready
3. Put the JIRA ticket (if you have one) in the branch name 
-->