### PR TITLE
USPR-13707: Security Fix [USPR-13684..13707]: Bump Netty to 4.2.15.Final, Jackson to 2.21.5/3.1.4, Logback to 1.5.34

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,23 @@ allprojects {
 subprojects {
     configurations.configureEach {
         resolutionStrategy.eachDependency {
-            if (requested.group == 'tools.jackson.core' && requested.name == 'jackson-core'
-                    && requested.version != null && requested.version < '3.1.1') {
-                useVersion('3.1.1')
-                because('GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 maxDocumentLength bypass')
+            if (requested.group == 'tools.jackson.core'
+                    && requested.version != null && requested.version < '3.1.4') {
+                useVersion('3.1.4')
+                because('GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 maxDocumentLength bypass; ' +
+                        'GHSA-j3rv-43j4-c7qm / GHSA-rmj7-2vxq-3g9f / GHSA-hgj6-7826-r7m5 / GHSA-5jmj-h7xm-6q6v / ' +
+                        'GHSA-rcqc-6cw3-h962 / GHSA-9fxm-vc8v-hj55 / GHSA-5hh8-q8hv-fr38: jackson-databind 3.x deserialization vulnerabilities')
+            }
+            if (requested.group == 'com.fasterxml.jackson.core' && requested.name == 'jackson-databind'
+                    && requested.version != null && requested.version < '2.21.5') {
+                useVersion('2.21.5')
+                because('GHSA-j3rv-43j4-c7qm / GHSA-rmj7-2vxq-3g9f / GHSA-hgj6-7826-r7m5 / GHSA-5jmj-h7xm-6q6v / ' +
+                        'GHSA-rcqc-6cw3-h962 / GHSA-9fxm-vc8v-hj55 / GHSA-5hh8-q8hv-fr38: jackson-databind 2.x deserialization vulnerabilities')
+            }
+            if (requested.group == 'ch.qos.logback'
+                    && requested.version != null && requested.version < '1.5.34') {
+                useVersion('1.5.34')
+                because('GHSA-p47f-322f-whfh / GHSA-jhq6-gfmj-v8fx: logback-core deserialization of untrusted data / object injection')
             }
             if (requested.group == 'org.apache.tomcat.embed' && requested.name == 'tomcat-embed-core'
                     && requested.version != null && requested.version < '11.0.22') {
@@ -36,9 +49,13 @@ subprojects {
                 because('GHSA-rv64-5gf8-9qq8 / GHSA-x4m4-345f-5h5g / GHSA-24j9-x2wg-9qv6 / GHSA-gx5v-xp9w-j4cg: Apache Tomcat < 11.0.22 vulnerabilities')
             }
             if (requested.group == 'io.netty'
-                    && requested.version != null && requested.version < '4.2.13.Final') {
-                useVersion('4.2.13.Final')
-                because('GHSA-38f8-5428-x5cv: HTTP Request Smuggling in io.netty:netty-codec-http via malformed Transfer-Encoding headers')
+                    && requested.version != null && requested.version < '4.2.15.Final') {
+                useVersion('4.2.15.Final')
+                because('GHSA-38f8-5428-x5cv: HTTP Request Smuggling in io.netty:netty-codec-http via malformed Transfer-Encoding headers; ' +
+                        'GHSA-3qp7-7mw8-wx86 / GHSA-c2rx-5r8w-8xr2 / GHSA-cmm3-54f8-px4j / GHSA-x4gw-5cx5-pgmh / GHSA-676x-f7gg-47vc / ' +
+                        'GHSA-5pvg-856g-cp85 / GHSA-4grm-h2qv-h6w6 / GHSA-c653-97m9-rcg9 / GHSA-563q-j3cm-6jxm / GHSA-hvcg-qmg6-jm4c / ' +
+                        'GHSA-cq4q-cv5g-r8q5 / GHSA-c2gf-v879-257j / GHSA-5x3r-wrvg-rp6q / GHSA-xmv7-r254-6q78 / GHSA-w573-9ffj-6ff9: ' +
+                        'multiple Netty vulnerabilities fixed in 4.2.15.Final')
             }
         }
     }

--- a/examples/example-spring-boot-starter-web/build.gradle
+++ b/examples/example-spring-boot-starter-web/build.gradle
@@ -5,8 +5,10 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
-ext['jackson-bom.version'] = '3.1.1'
-ext['netty.version'] = '4.2.13.Final'
+ext['jackson-bom.version'] = '3.1.4'
+ext['jackson-2-bom.version'] = '2.21.5'
+ext['logback.version'] = '1.5.34'
+ext['netty.version'] = '4.2.15.Final'
 ext['tomcat.version'] = '11.0.22'
 
 dependencies {

--- a/examples/example-spring-boot-starter-webflux/build.gradle
+++ b/examples/example-spring-boot-starter-webflux/build.gradle
@@ -5,8 +5,10 @@ plugins {
     alias(libs.plugins.openapi.generator)
 }
 
-ext['jackson-bom.version'] = '3.1.1'
-ext['netty.version'] = '4.2.13.Final'
+ext['jackson-bom.version'] = '3.1.4'
+ext['jackson-2-bom.version'] = '2.21.5'
+ext['logback.version'] = '1.5.34'
+ext['netty.version'] = '4.2.15.Final'
 ext['tomcat.version'] = '11.0.22'
 
 dependencies {

--- a/openapi-validation-core/build.gradle
+++ b/openapi-validation-core/build.gradle
@@ -15,7 +15,7 @@ dependencies {
         }
         implementation('tools.jackson.core:jackson-core') {
             version {
-                strictly '[3.1.1,)'
+                strictly '[3.1.4,)'
             }
             because 'GHSA-2m67-wjpj-xhg9: Jackson Core 3.0.0-3.1.0 does not consistently enforce maxDocumentLength constraint, allowing DoS attacks. See https://github.com/getyourguide/openapi-validation-java/security/dependabot/41'
         }


### PR DESCRIPTION
## Summary
Fixes all 24 open Dependabot alerts on this repository (alerts #72–#103) by enforcing patched minimum versions for Netty, jackson-databind (2.x and 3.x lines) and Logback.

## Vulnerability Details

| Dependency | Patched version | Alerts | Advisories |
|---|---|---|---|
| `io.netty:*` | 4.2.15.Final | #72–#86 | GHSA-3qp7-7mw8-wx86 (IPv6 subnet filter bypass), GHSA-c2rx-5r8w-8xr2 (HTTP/3 unbounded header DoS), GHSA-cmm3-54f8-px4j (QUIC token handler), GHSA-x4gw-5cx5-pgmh (SNI 16 MiB pre-allocation), GHSA-676x-f7gg-47vc / GHSA-5pvg-856g-cp85 / GHSA-xmv7-r254-6q78 (DNS cache poisoning / bailiwick), GHSA-4grm-h2qv-h6w6 (QPACK memory exhaustion), GHSA-c653-97m9-rcg9 (trust manager hostname verification), GHSA-563q-j3cm-6jxm (HTTP/2 reset attack), GHSA-hvcg-qmg6-jm4c (HttpObjectDecoder), GHSA-cq4q-cv5g-r8q5 (QUIC reset token), GHSA-c2gf-v879-257j (ByteBuf refcount leak), GHSA-5x3r-wrvg-rp6q (MAX_CONCURRENT_STREAMS), GHSA-w573-9ffj-6ff9 (Unix-socket fd leak) |
| `com.fasterxml.jackson.core:jackson-databind` | 2.21.5 | #87, #89, #91, #93, #96, #97, #99 | GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f, GHSA-hgj6-7826-r7m5, GHSA-5jmj-h7xm-6q6v, GHSA-rcqc-6cw3-h962, GHSA-9fxm-vc8v-hj55, GHSA-5hh8-q8hv-fr38 |
| `tools.jackson.core:*` (Jackson 3) | 3.1.4 | #88, #90, #92, #94, #95, #98, #100 | same advisories, 3.x line |
| `ch.qos.logback:*` | 1.5.34 | #101, #103 | GHSA-p47f-322f-whfh, GHSA-jhq6-gfmj-v8fx (HardenedObjectInputStream object injection) |

## Changes
Follows the pattern established in #375–#377:
- **Root `build.gradle`**: bumped the existing `io.netty` resolutionStrategy rule to 4.2.15.Final; broadened the `tools.jackson.core:jackson-core` rule to the whole `tools.jackson.core` group at 3.1.4; added rules for `com.fasterxml.jackson.core:jackson-databind` (2.21.5) and `ch.qos.logback` (1.5.34).
- **Example apps**: bumped `netty.version` / `jackson-bom.version` ext overrides and added `jackson-2-bom.version` / `logback.version`. These are needed because the `io.spring.dependency-management` plugin re-pins managed versions after the root resolutionStrategy rules run.
- **`openapi-validation-core`**: raised the published `tools.jackson.core:jackson-core` strict constraint floor from 3.1.1 to 3.1.4 so library consumers also get the patched line.

All version groups are forced together (whole Netty / Jackson 3 / Logback groups) to avoid mixed-version incompatibilities; logback-classic and logback-core must match versions.

## Testing
- ✅ Verified patched versions resolve in the dependency trees of the example apps, spring-boot-starter, core and test modules (`dependencies` / `dependencyInsight`)
- ✅ `./gradlew checkstyleMain checkstyleTest pmdMain pmdTest test` passes locally (same tasks as CI)
- ℹ️ `:examples:examples-common:bootJar` fails on this branch **and on unmodified main** (no main class configured) — pre-existing, not run by CI

## References
- Jira: USPR-13684 – USPR-13707 (24 tickets, all for this repo)
- Alerts: https://github.com/getyourguide/openapi-validation-java/security/dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)